### PR TITLE
changed res.end to specify a callback so the error message will be wr…

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -7,5 +7,6 @@ function proxyError (err, req, res) {
     if (!res.headersSent) {
         res.writeHead(500);
     }
-    res.end('Error occured while trying to proxy to: '+ host + req.url);
+
+    res.end(function(){return res.end('Error occured while trying to proxy to: '+ host + req.url);});
 };

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -7,6 +7,5 @@ function proxyError (err, req, res) {
     if (!res.headersSent) {
         res.writeHead(500);
     }
-
     res.end(function(){return res.end('Error occured while trying to proxy to: '+ host + req.url);});
 };

--- a/test/handlers.spec.js
+++ b/test/handlers.spec.js
@@ -48,7 +48,7 @@ describe('handlers.proxyError(err, req, res, proxyOptions)', function () {
 
     it('should end the response and return error message', function () {
         handlers.proxyError(mockError, mockReq, mockRes, proxyOptions);
-        expect(errorMessage).to.equal('Error occured while trying to proxy to: localhost:3000/api');
+        expect(errorMessage()).to.equal('Error occured while trying to proxy to: localhost:3000/api');
     });
 
     it('should not set the http status code to: 500 if headers have already been sent', function () {
@@ -60,7 +60,7 @@ describe('handlers.proxyError(err, req, res, proxyOptions)', function () {
     it('should end the response and return error message', function () {
         mockRes.headersSent = true;
         handlers.proxyError(mockError, mockReq, mockRes, proxyOptions);
-        expect(errorMessage).to.equal('Error occured while trying to proxy to: localhost:3000/api');
+        expect(errorMessage()).to.equal('Error occured while trying to proxy to: localhost:3000/api');
     });
 
 });


### PR DESCRIPTION
…itten once the response stream is finished.