### PR TITLE
fix(websocket): fixes websocket upgrade when both config.ws and external .upgrade() are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [v0.15.x](https://github.com/chimurai/http-proxy-middleware/releases/tag/v0.15.x)
 - feat(pathRewrite): expose `req` object to pathRewrite function.
+- fix(websocket): fixes websocket upgrade when both config.ws and external .upgrade() are used.
 
 ## [v0.15.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v0.15.0)
 - feat(pathRewrite): support for custom pathRewrite function.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+var HPM  = require('./lib');
+
+module.exports = function(context, opts) {
+    return new HPM(context, opts);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,15 @@
 var httpProxy      = require('http-proxy');
-var configFactory  = require('./lib/config-factory');
-var handlers       = require('./lib/handlers');
-var contextMatcher = require('./lib/context-matcher');
-var PathRewriter   = require('./lib/path-rewriter');
-var ProxyTable     = require('./lib/proxy-table');
-var logger         = require('./lib/logger').getInstance();
-var getArrow       = require('./lib/logger').getArrow;
+var configFactory  = require('./config-factory');
+var handlers       = require('./handlers');
+var contextMatcher = require('./context-matcher');
+var PathRewriter   = require('./path-rewriter');
+var ProxyTable     = require('./proxy-table');
+var logger         = require('./logger').getInstance();
+var getArrow       = require('./logger').getArrow;
 
-var httpProxyMiddleware = function(context, opts) {
+module.exports = HttpProxyMiddleware;
+
+function HttpProxyMiddleware(context, opts) {
     var isWsUpgradeListened = false;
     var config              = configFactory.createConfig(context, opts);
     var proxyOptions        = config.options;
@@ -123,7 +125,4 @@ var httpProxyMiddleware = function(context, opts) {
 
         logger.error('[HPM] PROXY ERROR: %s. %s -> %s', err.code, hostname, targetUri);
     }
-
 };
-
-module.exports = httpProxyMiddleware;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-proxy-middleware",
-  "version": "0.15.0",
+  "version": "0.15.1-beta",
   "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fixes #57 