### PR TITLE
fix(Express Router): breaking unmatched paths (non proxy routes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.18.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v0.18.0)
+- fix(Express sub Router): 404 on non-proxy routes  ([#94](https://github.com/chimurai/http-proxy-middleware/issues/94))
+
 ## [v0.17.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v0.17.0)
 - fix(context matching): Use [RFC 3986 path](https://tools.ietf.org/html/rfc3986#section-3.3) in context matching. (excludes query parameters)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,10 +35,7 @@ function HttpProxyMiddleware(context, opts) {
     return middleware;
 
     function middleware(req, res, next) {
-        // https://github.com/chimurai/http-proxy-middleware/issues/17
-        req.url = req.originalUrl;
-
-        if (contextMatcher.match(config.context, req.url, req)) {
+        if (shouldProxy(config.context, req)) {
             var activeProxyOptions = prepareProxyRequest(req);
             proxy.web(req, res, activeProxyOptions);
         } else {
@@ -55,11 +52,22 @@ function HttpProxyMiddleware(context, opts) {
     }
 
     function handleUpgrade(req, socket, head) {
-        if (contextMatcher.match(config.context, req.url, req)) {
+        if (shouldProxy(config.context, req)) {
             var activeProxyOptions = prepareProxyRequest(req);
             proxy.ws(req, socket, head, activeProxyOptions);
             logger.info('[HPM] Upgrading to WebSocket');
         }
+    }
+
+    /**
+     * Determine whether request should be proxied.
+     *
+     * @private
+     * @return {Boolean}
+     */
+    function shouldProxy(context, req) {
+        var path = (req.originalUrl || req.url);
+        return contextMatcher.match(context, path, req);
     }
 
     /**
@@ -69,6 +77,10 @@ function HttpProxyMiddleware(context, opts) {
           NOT the modified path, after it has been rewritten by pathRewrite
      */
     function prepareProxyRequest(req) {
+        // https://github.com/chimurai/http-proxy-middleware/issues/17
+        // https://github.com/chimurai/http-proxy-middleware/issues/94
+        req.url = (req.originalUrl || req.url);
+
         // store uri before it gets rewritten for logging
         var originalPath = req.url;
         var newProxyOptions = _.cloneDeep(proxyOptions);

--- a/test/e2e/express-router.spec.js
+++ b/test/e2e/express-router.spec.js
@@ -1,0 +1,67 @@
+var express = require('express');
+var expect  = require('chai').expect;
+var http    = require('http');
+var proxy   = require('../../index');
+
+describe('Usage in Express', function() {
+
+    var app;
+    var server;
+
+    beforeEach(function() {
+        app = express();
+    });
+
+    afterEach(function() {
+        server && server.close();
+    });
+
+    // https://github.com/chimurai/http-proxy-middleware/issues/94
+    describe('Express Sub Route', function() {
+
+        beforeEach(function() {
+
+            // sub route config
+            var sub = new express.Router();
+
+            function filter(pathname, req) {
+                var urlFilter = new RegExp('^/sub/api');
+                var match = urlFilter.test(pathname);
+                return match;
+            }
+
+            /**
+             * Mount proxy without 'path' in sub route
+             */
+            var proxyConfig = {target: 'http://jsonplaceholder.typicode.com', changeOrigin: true, logLevel: 'silent'};
+            sub.use(proxy(filter, proxyConfig));
+
+            sub.get('/hello', jsonMiddleware({'content': 'foobar'}));
+
+            // configure sub route on /sub junction
+            app.use('/sub', sub);
+
+            // start server
+            server = app.listen(3000);
+        });
+
+        it('should still return a response when route does not match proxyConfig', function(done) {
+            var responseBody;
+            http.get('http://localhost:3000/sub/hello', function(res) {
+                res.on('data', function(chunk) {
+                    responseBody = chunk.toString();
+                    expect(responseBody).to.equal('{"content":"foobar"}');
+                    done();
+                });
+            });
+        });
+
+    });
+
+    function jsonMiddleware(data) {
+        return function(req, res) {
+            res.json(data);
+        };
+    }
+
+});


### PR DESCRIPTION
fixes #94 

`req.url` get rewritten even for non proxy routes.

Fix:
Only rewrite `req.url` when proxy routes matches.