### PR TITLE
feat(logging): improve error message & add link to Node errors page.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,6 @@ function HttpProxyMiddleware(context, opts) {
         var target = proxyOptions.target.host || proxyOptions.target;
         var errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors'; // link to Node Common Systems Errors page
 
-        logger.error('[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) \n(%s)', req.url, hostname, target, err.code, errReference);
+        logger.error('[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) (%s)', req.url, hostname, target, err.code, errReference);
     }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var _              = require('lodash');
 var httpProxy      = require('http-proxy');
+var errno          = require('errno');
 var configFactory  = require('./config-factory');
 var handlers       = require('./handlers');
 var contextMatcher = require('./context-matcher');
@@ -128,9 +129,14 @@ function HttpProxyMiddleware(context, opts) {
     }
 
     function logError(err, req, res) {
-        var hostname = (req.hostname || req.host) || (req.headers && req.headers.host); // (node0.10 || node 4/5) || (websocket)
-        var targetUri = (proxyOptions.target.host || proxyOptions.target) + req.url;
-
-        logger.error('[HPM] PROXY ERROR: %s. %s -> %s', err.code, hostname, targetUri);
+        var hostname = (req.headers && req.headers.host) || (req.hostname || req.host); // (websocket) || (node0.10 || node 4/5)
+        var target = proxyOptions.target.host || proxyOptions.target;
+        var description =  errno.code[err.code] && errno.code[err.code].description;    //  description for the error code
+        
+        if (description) {
+            logger.error('[HPM] Error \'%s\' (ErrorCode=%s) occurred while trying to proxy request %s from %s to %s', description, err.code, req.url, hostname, target);
+        } else {
+            logger.error('[HPM] Error (ErrorCode=%s) occurred while trying to proxy request %s from %s to %s', err.code, req.url, hostname, target);
+        }
     }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 var _              = require('lodash');
 var httpProxy      = require('http-proxy');
-var errno          = require('errno');
 var configFactory  = require('./config-factory');
 var handlers       = require('./handlers');
 var contextMatcher = require('./context-matcher');
@@ -129,14 +128,10 @@ function HttpProxyMiddleware(context, opts) {
     }
 
     function logError(err, req, res) {
-        var hostname = (req.headers && req.headers.host) || (req.hostname || req.host); // (websocket) || (node0.10 || node 4/5)
+        var hostname = (req.headers && req.headers.host) || (req.hostname || req.host);     // (websocket) || (node0.10 || node 4/5)
         var target = proxyOptions.target.host || proxyOptions.target;
-        var description =  errno.code[err.code] && errno.code[err.code].description;    //  description for the error code
-        
-        if (description) {
-            logger.error('[HPM] Error \'%s\' (ErrorCode=%s) occurred while trying to proxy request %s from %s to %s', description, err.code, req.url, hostname, target);
-        } else {
-            logger.error('[HPM] Error (ErrorCode=%s) occurred while trying to proxy request %s from %s to %s', err.code, req.url, hostname, target);
-        }
+        var errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors'; // link to Node Common Systems Errors page
+
+        logger.error('[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) \n(%s)', req.url, hostname, target, err.code, errReference);
     }
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "http-proxy": "^1.14.0",
     "is-glob": "^2.0.1",
     "lodash": "^4.14.2",
-    "micromatch": "^2.3.11",
-    "errno": "^0.1.4"
+    "micromatch": "^2.3.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "http-proxy": "^1.14.0",
     "is-glob": "^2.0.1",
     "lodash": "^4.14.2",
-    "micromatch": "^2.3.11"
+    "micromatch": "^2.3.11",
+    "errno": "^0.1.4"
   }
 }


### PR DESCRIPTION
This will add error description when logging errors. 

1. The error descriptions are "standard" descriptions supported by Node module [errno](https://www.npmjs.com/package/errno), see Node [Common System Errors](https://nodejs.org/api/errors.html#errors_class_system_error) and [POSIX errno](http://man7.org/linux/man-pages/man3/errno.3.html)

2. The error message format is also slightly modified, hopefully to be more beginner friendly. See an error example in the console of a [create-react-app](https://github.com/facebookincubator/create-react-app) test application.

![hpm-error log](https://cloud.githubusercontent.com/assets/3992029/18104534/7f4725f8-6ec9-11e6-8182-7ce56ab2593e.png)

HPM is used by create-react-app for [Proxying API Requests](https://github.com/facebookincubator/create-react-app/blob/ef94b0561d5afb9b50b905fa5cd3f94e965c69c0/template/README.md#proxying-api-requests-in-development).   create-react-app expects more beginner friendly error messages. See [pull request](https://github.com/facebookincubator/create-react-app/pull/502).