### PR TITLE
bug(websocket): memory leak when option 'ws:true' is used.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ module.exports = HttpProxyMiddleware;
 function HttpProxyMiddleware(context, opts) {
     // https://github.com/chimurai/http-proxy-middleware/issues/57
     var wsUpgradeDebounced  = _.debounce(handleUpgrade);
+    var wsInitialized       = false;
     var config              = configFactory.createConfig(context, opts);
     var proxyOptions        = config.options;
 
@@ -43,15 +44,24 @@ function HttpProxyMiddleware(context, opts) {
         }
 
         if (proxyOptions.ws === true) {
+            // use initial request to access the server object to subscribe to http upgrade event
             catchUpgradeRequest(req.connection.server);
         }
     }
 
     function catchUpgradeRequest(server) {
-        server.on('upgrade', wsUpgradeDebounced);
+        // subscribe once; don't subscribe on every request...
+        // https://github.com/chimurai/http-proxy-middleware/issues/113
+        if (!wsInitialized) {
+            server.on('upgrade', wsUpgradeDebounced);
+            wsInitialized = true;
+        }
     }
 
     function handleUpgrade(req, socket, head) {
+        // set to initialized when used externally
+        wsInitialized = true;
+
         if (shouldProxy(config.context, req)) {
             var activeProxyOptions = prepareProxyRequest(req);
             proxy.ws(req, socket, head, activeProxyOptions);


### PR DESCRIPTION
fixes #113 