### PR TITLE
fix(ntlm authentication)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ function HttpProxyMiddleware(context, opts) {
 
         // store uri before it gets rewritten for logging
         var originalPath = req.url;
-        var newProxyOptions = _.cloneDeep(proxyOptions);
+        var newProxyOptions = _.assign({}, proxyOptions);
 
         // Apply in order:
         // 1. option.router


### PR DESCRIPTION
fix #39 - proxy ntlm authentication

```
_stream_writable.js:361
  cb();
  ^

TypeError: cb is not a function
    at afterWrite (_stream_writable.js:361:3)
    at onwrite (_stream_writable.js:352:7)
    at WritableState.onwrite (_stream_writable.js:89:5)
    at Socket._writeGeneric (net.js:714:5)
    at Socket._write (net.js:724:8)
    at doWrite (_stream_writable.js:307:12)
    at writeOrBuffer (_stream_writable.js:293:5)
    at Socket.Writable.write (_stream_writable.js:220:11)
    at Socket.write (net.js:650:40)
    at ClientRequest.OutgoingMessage._writeRaw (_http_outgoing.js:167:23)
```