### PR TITLE
update router to check req.url matched path

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -28,7 +28,7 @@ function getTargetFromProxyTable(req, table) {
     _.forIn(table, function(value, key) {
         if (containsPath(key)) {
 
-            if (hostAndPath.indexOf(key) > -1) {    // match 'localhost:3000/api'
+            if (hostAndPath.indexOf(key) == 0 || path.indexOf(key) == 0) {    // match 'localhost:3000/api'
                 result = table[key];
                 logger.debug('[HPM] Router table match: "%s"', key);
                 return false;


### PR DESCRIPTION
For special case with req.url 'http://host/user/vm/counter' and
```
router =
  '/vm/': 'http://192.168.1.1:8000'
  '/user/': 'http://192.179.1.1:8001'
```
Router would forward the request to 1st matched handler instead of the expected 2nd handler. This pull request is to ensure the matching to the first character of path or hostAndPath. Please review.