### PR TITLE
Allow customization of proxy options on a per-request basis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function HttpProxyMiddleware (context, opts) {
       var activeProxyOptions = prepareProxyRequest(req)
 
       if (activeProxyOptions.onBeforeProxy) {
-        activeProxyOptions.onBeforeProxy(req, res, proxyOptions);
+        activeProxyOptions.onBeforeProxy(req, res, proxyOptions)
       }
 
       proxy.web(req, res, activeProxyOptions)

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,11 @@ function HttpProxyMiddleware (context, opts) {
   function middleware (req, res, next) {
     if (shouldProxy(config.context, req)) {
       var activeProxyOptions = prepareProxyRequest(req)
+
+      if (activeProxyOptions.onBeforeProxy) {
+        activeProxyOptions.onBeforeProxy(req, res, proxyOptions);
+      }
+
       proxy.web(req, res, activeProxyOptions)
     } else {
       next()

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function HttpProxyMiddleware (context, opts) {
       var activeProxyOptions = prepareProxyRequest(req)
 
       if (activeProxyOptions.onBeforeProxy) {
-        activeProxyOptions.onBeforeProxy(req, res, proxyOptions)
+        activeProxyOptions.onBeforeProxy(req, res, activeProxyOptions)
       }
 
       proxy.web(req, res, activeProxyOptions)


### PR DESCRIPTION
We need access to change `options.ssl.servername` on a per-request basis to correctly route HTTPS traffic. Currently the `options` object cannot be modified on a per-request basis, but is set once. This PR suggests allowing a user to provide a callback before making each proxy request.

Would this be an amenable method of allowing this?

Users could utilize this feature like so:

    var proxy = require('http-proxy-middleware');
    var express = require('express');
    let app = express();
    let config = { onBeforeProxy: (req, res, options) => {
            options.ssl = { servername: req.hostname.replace('my', envId)};
        };
    app.use('/', proxy(config));