### PR TITLE
Add recipe for proxy to HTTPS servers

### DIFF
--- a/recipes/https.md
+++ b/recipes/https.md
@@ -1,0 +1,34 @@
+# HTTPS
+
+How to proxy requests to various types of HTTPS servers.
+
+All options are provided by [http-proxy](https://github.com/nodejitsu/node-http-proxy).
+
+## Basic proxy to an HTTPS server
+
+```javascript
+var proxy = require('http-proxy-middleware');
+
+var apiProxy = proxy('/api', {
+    target: 'https://example.org',
+    changeOrigin: true,
+});
+```
+
+## Proxy to an HTTPS server using a PKCS12 client certificate
+
+```javascript
+var fs = require('fs');
+var proxy = require('http-proxy-middleware');
+
+var apiProxy = proxy('/api', {
+    target: {
+        protocol: 'https:',
+        host: 'example.org',
+        port: 443,
+        pfx: fs.readFileSync('path/to/certificate.p12'),
+        passphrase: 'password',
+    },
+    changeOrigin: true,
+});
+```


### PR DESCRIPTION
Hello again! :slightly_smiling_face:

Recently I was working with proxy requests to HTTPS servers. In my specific case I had to use a PKCS12 client certificate to authenticate on the remote server (the type you normally import in your browser).

After looking into the code and old issues of the [http-proxy](https://github.com/nodejitsu/node-http-proxy) package, I made a working example.

I already submitted a pull request there: nodejitsu/node-http-proxy#1209. I thought a little bit of documentation could help other people in the future, so I added a new `https.md` recipe.