### PR TITLE
error logging ignores router target

### DIFF
--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -169,7 +169,9 @@ export class HttpProxyMiddleware {
   private logError = (err, req, res) => {
     const hostname =
       (req.headers && req.headers.host) || (req.hostname || req.host); // (websocket) || (node0.10 || node 4/5)
-    const target = this.proxyOptions.target.host || this.proxyOptions.target;
+    const routerTarget = Router.getTarget(req, this.proxyOptions);
+    const target =
+      routerTarget || this.proxyOptions.target.host || this.proxyOptions.target;
     const errorMessage =
       '[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) (%s)';
     const errReference =


### PR DESCRIPTION
Hi,

I'm using a router function to override the target. If an error occurs the old target is written to the log which can be really misleading.
I changed the logging so that it first gets the router target and then uses one of the available targets for output.