### PR TITLE
Update logging of proxy creation in 'test'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ function HttpProxyMiddleware (context, opts) {
 
   // create proxy
   var proxy = httpProxy.createProxyServer({})
-  
+
   // Prevent logging during tests
   if (process.env.NODE_ENV !== 'test') {
     logger.info('[HPM] Proxy created:', config.context, ' -> ', proxyOptions.target)

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,11 @@ function HttpProxyMiddleware (context, opts) {
 
   // create proxy
   var proxy = httpProxy.createProxyServer({})
-  logger.info('[HPM] Proxy created:', config.context, ' -> ', proxyOptions.target)
+  
+  // Prevent logging during tests
+  if (process.env.NODE_ENV !== 'test') {
+    logger.info('[HPM] Proxy created:', config.context, ' -> ', proxyOptions.target)
+  }
 
   var pathRewriter = PathRewriter.create(proxyOptions.pathRewrite) // returns undefined when "pathRewrite" is not provided
 


### PR DESCRIPTION
Allow users to prevent logging while running tests so that these logs do not interfere with test logs.