### PR TITLE
Log err.reason when no err.code is availiable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,6 +147,6 @@ function HttpProxyMiddleware (context, opts) {
     var errorMessage = '[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) (%s)'
     var errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors' // link to Node Common Systems Errors page
 
-    logger.error(errorMessage, req.url, hostname, target, err.code, errReference)
+    logger.error(errorMessage, req.url, hostname, target, err.code || err.reason, errReference)
   }
 }


### PR DESCRIPTION
When connecting to https resource, the error can have no code. Lets display err.reason instead

ie.:
```
err { Error: Hostname/IP doesn't match certificate's altnames: "Host: localhost. is not in the cert's altnames: DNS:..."
    at Object.checkServerIdentity (tls.js:222:17)
    at TLSSocket.<anonymous> (_tls_wrap.js:1109:29)
    at emitNone (events.js:106:13)
    at TLSSocket.emit (events.js:208:7)
    at TLSSocket._finishInit (_tls_wrap.js:637:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:467:38)
  reason: 'Host: localhost. is not in the cert\'s altnames: DNS:...,
  host: 'localhost',
  cert: ...
```

Otherwise the log looks like this: (see ` (undefined) `)
```
[HPM] Error occurred while trying to proxy request /url/sth/sth from localhost:3009 to https://example.com (undefined) (https://nodejs.org/api/errors.html#errors_common_system_errors)
```