### PR TITLE
fix(log): Handle case when error code is missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,6 +147,6 @@ function HttpProxyMiddleware (context, opts) {
     var errorMessage = '[HPM] Error occurred while trying to proxy request %s from %s to %s (%s) (%s)'
     var errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors' // link to Node Common Systems Errors page
 
-    logger.error(errorMessage, req.url, hostname, target, err.code, errReference)
+    logger.error(errorMessage, req.url, hostname, target, err.code || err, errReference)
   }
 }


### PR DESCRIPTION
To reproduce supply a custom certificate with altnames (e.g. `localhost:5000`) that does not include `localhost:<port>` and start server on `localhost:<port>` (e.g. `localhost:3000`).

## Before
```
[HPM] Error occurred while trying to proxy request <redacted> from <redacted> to <redacted> (undefined) (https://nodejs.org/api/errors.html#errors_common_system_errors)
```

## After
```
[HPM] Error occurred while trying to proxy request <redacted> from <redacted> to <redacted> (Error: Hostname/IP doesn't match certificate's altnames: "Host: <redacted>. is not in the cert's altnames: DNS:<redacted>, DNS:<redacted>") (https://nodejs.org/api/errors.html#errors_common_system_errors)
```
