### PR TITLE
feat: async router

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ Providing an alternative way to decide which requests should be proxied; In case
   router: function(req) {
       return 'http://localhost:8004';
   }
+
+  // Asynchronous router function which returns promise
+  router: async function(req) {
+      const url = await doSomeIO();
+      return url;
+  }
   ```
 
 - **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -97,7 +97,7 @@ export class HttpProxyMiddleware {
    * @param {Object} req
    * @return {Object} proxy options
    */
-  private prepareProxyRequest = async (req) => {
+  private prepareProxyRequest = async req => {
     // https://github.com/chimurai/http-proxy-middleware/issues/17
     // https://github.com/chimurai/http-proxy-middleware/issues/94
     req.url = req.originalUrl || req.url;

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,14 +2,14 @@ import * as _ from 'lodash';
 import { getInstance } from './logger';
 const logger = getInstance();
 
-export function getTarget(req, config) {
+export async function getTarget(req, config) {
   let newTarget;
   const router = config.router;
 
   if (_.isPlainObject(router)) {
     newTarget = getTargetFromProxyTable(req, router);
   } else if (_.isFunction(router)) {
-    newTarget = router(req);
+    newTarget = await router(req);
   }
 
   return newTarget;

--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -40,7 +40,7 @@ describe('router unit test', () => {
         expect(request.url).toBe('/');
       });
       it('should return new target', () => {
-        expect(result).toBe('http://foobar.com:666');
+        expect(result).resolves.toBe('http://foobar.com:666');
       });
     });
   });
@@ -64,7 +64,7 @@ describe('router unit test', () => {
     describe('without router config', () => {
       it('should return the normal target when router not present in config', () => {
         result = getTarget(fakeReq, config);
-        expect(result).toBeUndefined();
+        expect(result).resolves.toBeUndefined();
       });
     });
 
@@ -72,13 +72,13 @@ describe('router unit test', () => {
       it('should target http://localhost:6001 when for router:"alpha.localhost"', () => {
         fakeReq.headers.host = 'alpha.localhost';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6001');
+        expect(result).resolves.toBe('http://localhost:6001');
       });
 
       it('should target http://localhost:6002 when for router:"beta.localhost"', () => {
         fakeReq.headers.host = 'beta.localhost';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6002');
+        expect(result).resolves.toBe('http://localhost:6002');
       });
     });
 
@@ -86,21 +86,21 @@ describe('router unit test', () => {
       it('should target http://localhost:6004 without path', () => {
         fakeReq.headers.host = 'gamma.localhost';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6004');
+        expect(result).resolves.toBe('http://localhost:6004');
       });
 
       it('should target http://localhost:6003 exact path match', () => {
         fakeReq.headers.host = 'gamma.localhost';
         fakeReq.url = '/api';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6003');
+        expect(result).resolves.toBe('http://localhost:6003');
       });
 
       it('should target http://localhost:6004 when contains path', () => {
         fakeReq.headers.host = 'gamma.localhost';
         fakeReq.url = '/api/books/123';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6003');
+        expect(result).resolves.toBe('http://localhost:6003');
       });
     });
 
@@ -108,19 +108,19 @@ describe('router unit test', () => {
       it('should target http://localhost:6005 with just a path as router config', () => {
         fakeReq.url = '/rest';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6005');
+        expect(result).resolves.toBe('http://localhost:6005');
       });
 
       it('should target http://localhost:6005 with just a path as router config', () => {
         fakeReq.url = '/rest/deep/path';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6005');
+        expect(result).resolves.toBe('http://localhost:6005');
       });
 
       it('should target http://localhost:6000 path in not present in router config', () => {
         fakeReq.url = '/unknow-path';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBeUndefined();
+        expect(result).resolves.toBeUndefined();
       });
     });
 
@@ -128,7 +128,7 @@ describe('router unit test', () => {
       it('should return first matching target when similar paths are configured', () => {
         fakeReq.url = '/some/specific/path';
         result = getTarget(fakeReq, proxyOptionWithRouter);
-        expect(result).toBe('http://localhost:6006');
+        expect(result).resolves.toBe('http://localhost:6006');
       });
     });
   });

--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -45,6 +45,32 @@ describe('router unit test', () => {
     });
   });
 
+  describe('router.getTarget from async function', () => {
+    let request;
+
+    beforeEach(() => {
+      proxyOptionWithRouter = {
+        target: 'http://localhost:6000',
+        async router(req) {
+          request = req;
+          return 'http://foobar.com:666';
+        }
+      };
+
+      result = getTarget(fakeReq, proxyOptionWithRouter);
+    });
+
+    describe('custom dynamic router async function', () => {
+      it('should provide the request object for dynamic routing', () => {
+        expect(request.headers.host).toBe('localhost');
+        expect(request.url).toBe('/');
+      });
+      it('should return new target', () => {
+        expect(result).resolves.toBe('http://foobar.com:666');
+      });
+    });
+  });
+
   describe('router.getTarget from table', () => {
     beforeEach(() => {
       proxyOptionWithRouter = {


### PR DESCRIPTION
hello,
this PR adds support for **options.router** for async handlers.

It came up in this issue: https://github.com/chimurai/http-proxy-middleware/issues/153

I would be glad to also add tests, but it seems like instructions are missing since it expects a running server on port 8000/3000.. please provide and i'll complete the tests