### PR TITLE
fix(typescript): fix proxyRes and router types

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,17 @@ Providing an alternative way to decide which requests should be proxied; In case
       '/rest'                      : 'http://localhost:8004'   // path only
   }
 
-  // Custom router function
+  // Custom router function (string target)
+  router: function(req) {
+      return 'http://localhost:8004';
+  }
+
+  // Custom router function (target object)
   router: function(req) {
       return {
-        protocol: 'https:', // The : is required
-        host: 'localhost',
-        port: 8004
+          protocol: 'https:', // The : is required
+          host: 'localhost',
+          port: 8004
       };
   }
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ Providing an alternative way to decide which requests should be proxied; In case
     if (should_add_something) path += "something";
     return path;
   }
-
   ```
 
 - **option.router**: object/function, re-target `option.target` for specific requests.
@@ -245,7 +244,11 @@ Providing an alternative way to decide which requests should be proxied; In case
 
   // Custom router function
   router: function(req) {
-      return 'http://localhost:8004';
+      return {
+        protocol: 'https:', // The : is required
+        host: 'localhost',
+        port: 8004
+      };
   }
 
   // Asynchronous router function which returns promise

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,14 +18,14 @@ export interface Options extends httpProxy.ServerOptions {
     | ((path: string, req: Request) => string)
     | ((path: string, req: Request) => Promise<string>);
   router?:
-    | { [hostOrPath: string]: string }
-    | ((req: Request) => string)
-    | ((req: Request) => Promise<string>);
+    | { [hostOrPath: string]: httpProxy.ServerOptions['target'] }
+    | ((req: Request) => httpProxy.ServerOptions['target'])
+    | ((req: Request) => Promise<httpProxy.ServerOptions['target']>);
   logLevel?: 'debug' | 'info' | 'warn' | 'error' | 'silent';
   logProvider?(provider: LogProvider): LogProvider;
 
   onError?(err: Error, req: Request, res: Response): void;
-  onProxyRes?(proxyRes: http.ServerResponse, req: Request, res: Response): void;
+  onProxyRes?(proxyRes: http.IncomingMessage, req: Request, res: Response): void;
   onProxyReq?(proxyReq: http.ClientRequest, req: Request, res: Response): void;
   onProxyReqWs?(
     proxyReq: http.ClientRequest,

--- a/test/e2e/router.spec.ts
+++ b/test/e2e/router.spec.ts
@@ -28,13 +28,13 @@ describe('E2E router', () => {
 
     await targetServerA
       .anyRequest()
-      .thenCallback(request => ({ body: request.protocol === 'https' ? 'A' : 'NOT HTTPS A' }));
+      .thenCallback(({ protocol }) => ({ body: protocol === 'https' ? 'A' : 'NOT HTTPS A' }));
     await targetServerB
       .anyRequest()
-      .thenCallback(request => ({ body: request.protocol === 'https' ? 'B' : 'NOT HTTPS B' }));
+      .thenCallback(({ protocol }) => ({ body: protocol === 'https' ? 'B' : 'NOT HTTPS B' }));
     await targetServerC
       .anyRequest()
-      .thenCallback(request => ({ body: request.protocol === 'https' ? 'C' : 'NOT HTTPS C' }));
+      .thenCallback(({ protocol }) => ({ body: protocol === 'https' ? 'C' : 'NOT HTTPS C' }));
 
     await targetServerA.start(6001);
     await targetServerB.start(6002);

--- a/test/e2e/router.spec.ts
+++ b/test/e2e/router.spec.ts
@@ -1,6 +1,10 @@
 import { createProxyMiddleware, createApp, createAppWithPath } from './_utils';
 import * as request from 'supertest';
-import { getLocal, Mockttp } from 'mockttp';
+import { getLocal, generateCACertificate, Mockttp } from 'mockttp';
+
+const untrustedCACert = generateCACertificate({ bits: 1024 });
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 describe('E2E router', () => {
   let targetServerA: Mockttp;
@@ -8,17 +12,33 @@ describe('E2E router', () => {
   let targetServerC: Mockttp;
 
   beforeEach(async () => {
-    targetServerA = getLocal();
-    targetServerB = getLocal();
-    targetServerC = getLocal();
+    targetServerA = getLocal({ https: await untrustedCACert });
+    targetServerB = getLocal({ https: await untrustedCACert });
+    targetServerC = getLocal({ https: await untrustedCACert });
+
+    await targetServerA
+      .anyRequest()
+      .thenPassThrough({ ignoreHostCertificateErrors: ['localhost'] });
+    await targetServerB
+      .anyRequest()
+      .thenPassThrough({ ignoreHostCertificateErrors: ['localhost'] });
+    await targetServerC
+      .anyRequest()
+      .thenPassThrough({ ignoreHostCertificateErrors: ['localhost'] });
+
+    await targetServerA
+      .anyRequest()
+      .thenCallback(request => ({ body: request.protocol === 'https' ? 'A' : 'NOT HTTPS A' }));
+    await targetServerB
+      .anyRequest()
+      .thenCallback(request => ({ body: request.protocol === 'https' ? 'B' : 'NOT HTTPS B' }));
+    await targetServerC
+      .anyRequest()
+      .thenCallback(request => ({ body: request.protocol === 'https' ? 'C' : 'NOT HTTPS C' }));
 
     await targetServerA.start(6001);
     await targetServerB.start(6002);
     await targetServerC.start(6003);
-
-    targetServerA.get().thenReply(200, 'A');
-    targetServerB.get().thenReply(200, 'B');
-    targetServerC.get().thenReply(200, 'C');
   });
 
   afterEach(async () => {
@@ -27,13 +47,15 @@ describe('E2E router', () => {
     await targetServerC.stop();
   });
 
-  describe('router with proxyTable', () => {
-    it('should proxy to: "localhost:6003/api"', async () => {
+  describe('router with req', () => {
+    it('should work with a string', async () => {
       const app = createApp(
         createProxyMiddleware({
-          target: `http://localhost:6001`,
+          target: 'https://localhost:6001',
+          secure: false,
+          changeOrigin: true,
           router(req) {
-            return 'http://localhost:6003';
+            return 'https://localhost:6003';
           }
         })
       );
@@ -41,6 +63,60 @@ describe('E2E router', () => {
       const agent = request(app);
       const response = await agent.get('/api').expect(200);
       expect(response.text).toBe('C');
+    });
+
+    it('should work with an object', async () => {
+      const app = createApp(
+        createProxyMiddleware({
+          target: 'https://localhost:6001',
+          secure: false,
+          changeOrigin: true,
+          router(req) {
+            return { host: 'localhost', port: 6003, protocol: 'https:' };
+          }
+        })
+      );
+      const agent = request(app);
+      const response = await agent.get('/api').expect(200);
+      expect(response.text).toBe('C');
+    });
+
+    it('should work with an async callback', async () => {
+      const app = createApp(
+        createProxyMiddleware({
+          target: 'https://localhost:6001',
+          secure: false,
+          changeOrigin: true,
+          router: async req => {
+            return new Promise(resolve =>
+              resolve({ host: 'localhost', port: 6003, protocol: 'https:' })
+            );
+          }
+        })
+      );
+
+      const agent = request(app);
+      const response = await agent.get('/api').expect(200);
+      expect(response.text).toBe('C');
+    });
+
+    it('missing a : will cause it to use http', async () => {
+      const app = createApp(
+        createProxyMiddleware({
+          target: 'https://localhost:6001',
+          secure: false,
+          changeOrigin: true,
+          router: async req => {
+            return new Promise(resolve =>
+              resolve({ host: 'localhost', port: 6003, protocol: 'https' })
+            );
+          }
+        })
+      );
+
+      const agent = request(app);
+      const response = await agent.get('/api').expect(200);
+      expect(response.text).toBe('NOT HTTPS C');
     });
   });
 
@@ -51,11 +127,13 @@ describe('E2E router', () => {
       const app = createAppWithPath(
         '/',
         createProxyMiddleware({
-          target: 'http://localhost:6001',
+          target: 'https://localhost:6001',
+          secure: false,
+          changeOrigin: true,
           router: {
-            'alpha.localhost:6000': 'http://localhost:6001',
-            'beta.localhost:6000': 'http://localhost:6002',
-            'localhost:6000/api': 'http://localhost:6003'
+            'alpha.localhost:6000': 'https://localhost:6001',
+            'beta.localhost:6000': 'https://localhost:6002',
+            'localhost:6000/api': 'https://localhost:6003'
           }
         })
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,8 +1692,8 @@ cookie@0.4.0:
 
 cookiejar@^2.1.0:
   version "2.1.2"
-  resolved "https://martifactory.io/api/npm/virtual-npm/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
-  integrity sha1-3YojVTB1L5iPmghE8/xYnjERElw=
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -2482,8 +2482,8 @@ forever-agent@~0.6.1:
 
 form-data@^2.3.1:
   version "2.5.1"
-  resolved "https://martifactory.io/api/npm/virtual-npm/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
@@ -2499,9 +2499,9 @@ form-data@~2.3.2:
     mime-types "^2.1.12"
 
 formidable@^1.2.0:
-  version "1.2.2"
-  resolved "https://martifactory.io/api/npm/virtual-npm/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
-  integrity sha1-v2muopcpgmdfAIZTQrmCmG9rjdk=
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4862,8 +4862,8 @@ qs@6.7.0:
 
 qs@^6.5.1:
   version "6.9.1"
-  resolved "https://martifactory.io/api/npm/virtual-npm/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
-  integrity sha1-IAgsZct4IjY1qxqerKiHWim/jsk=
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -5830,8 +5830,8 @@ subscriptions-transport-ws@^0.9.4:
 
 superagent@^3.8.3:
   version "3.8.3"
-  resolved "https://martifactory.io/api/npm/virtual-npm/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
-  integrity sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.1.0"
@@ -5846,8 +5846,8 @@ superagent@^3.8.3:
 
 supertest@^4.0.2:
   version "4.0.2"
-  resolved "https://martifactory.io/api/npm/virtual-npm/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
-  integrity sha1-wiNNvdbcebbxW5nI1ld7kOTOPzY=
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
+  integrity sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==
   dependencies:
     methods "^1.1.2"
     superagent "^3.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,8 +1692,8 @@ cookie@0.4.0:
 
 cookiejar@^2.1.0:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
-  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
+  resolved "https://martifactory.io/api/npm/virtual-npm/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha1-3YojVTB1L5iPmghE8/xYnjERElw=
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -2482,8 +2482,8 @@ forever-agent@~0.6.1:
 
 form-data@^2.3.1:
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  resolved "https://martifactory.io/api/npm/virtual-npm/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
@@ -2499,9 +2499,9 @@ form-data@~2.3.2:
     mime-types "^2.1.12"
 
 formidable@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
-  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
+  version "1.2.2"
+  resolved "https://martifactory.io/api/npm/virtual-npm/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha1-v2muopcpgmdfAIZTQrmCmG9rjdk=
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4862,8 +4862,8 @@ qs@6.7.0:
 
 qs@^6.5.1:
   version "6.9.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
-  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+  resolved "https://martifactory.io/api/npm/virtual-npm/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha1-IAgsZct4IjY1qxqerKiHWim/jsk=
 
 qs@~6.5.2:
   version "6.5.2"
@@ -5830,8 +5830,8 @@ subscriptions-transport-ws@^0.9.4:
 
 superagent@^3.8.3:
   version "3.8.3"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
-  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  resolved "https://martifactory.io/api/npm/virtual-npm/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.1.0"
@@ -5846,8 +5846,8 @@ superagent@^3.8.3:
 
 supertest@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
-  integrity sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==
+  resolved "https://martifactory.io/api/npm/virtual-npm/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
+  integrity sha1-wiNNvdbcebbxW5nI1ld7kOTOPzY=
   dependencies:
     methods "^1.1.2"
     superagent "^3.8.3"


### PR DESCRIPTION
* Fixes #407 
* Fixes #408 
* Explicit about `protocol` requiring `:` in README.
* Adds `https:` to router tests.
* Test `protocol: 'https'` to router tests showing `:` is required for `https` to work.