### PR TITLE
build(package): exclude build artifact tsconfig.tsbuildinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "precoveralls": "yarn clean && yarn build",
     "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
     "postcoveralls": "yarn clean",
-    "prepare": "yarn clean && yarn build"
+    "prepare": "yarn clean && yarn build && rm dist/tsconfig.tsbuildinfo"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
exclude build artifact tsconfig.tsbuildinfo

before:
>npm notice package size:  30.3 kB                                 
>npm notice unpacked size: 208.4 kB                                

after:
>npm notice package size:  17.1 kB                                 
>npm notice unpacked size: 61.0 kB                                 