### PR TITLE
fix: properly proxy the body

### DIFF
--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -180,8 +180,10 @@ export class HttpProxyMiddleware {
   };
 
   private fixBody = (proxyReq: ClientRequest, req: Request) => {
-    if (req.body instanceof Object) {
-      proxyReq.write(JSON.stringify(req.body));
+    if (req.is('application/json')) {
+      const bodyData = JSON.stringify(req.body);
+      proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+      proxyReq.write(bodyData);
     }
   };
 }


### PR DESCRIPTION
Things like `body-parser` can break proxying anything with a body. This
checks for that (`req.body` will become an `Object`) and streams the body
into the proxy request.

Fixes #90, #320, #417 - and maybe some more

