### PR TITLE
Preventing the fail of the 'ETIMEDOUT' code in 500 'Internal server error'

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -54,6 +54,7 @@ function defaultErrorHandler(err, req, res) {
         case 'ECONNRESET':
         case 'ENOTFOUND':
         case 'ECONNREFUSED':
+        case 'ETIMEDOUT':
           res.writeHead(504);
           break;
         default:

--- a/test/unit/handlers.spec.ts
+++ b/test/unit/handlers.spec.ts
@@ -104,6 +104,7 @@ describe('default proxy error handler', () => {
     ['ECONNREFUSED', 504],
     ['ENOTFOUND', 504],
     ['ECONNREFUSED', 504],
+    ['ETIMEDOUT', 504],
     ['any', 500],
   ];
 


### PR DESCRIPTION
Currently `ETIMEDOUT` code is handled by the `defaultErrorHandler` as a `[500] Internal Server Error`. 
It should be handled as the regular `ECONNRESET` || `ENOTFOUND` || `ECONNREFUSED` || `ETIMEDOUT` codes.