### PR TITLE
fix: change npm install dependency mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ _All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#option
 ## Install
 
 ```bash
-$ npm install --save-dev http-proxy-middleware
+$ npm install --save http-proxy-middleware
 ```
 
 ## Core concept


### PR DESCRIPTION
This commit has been changed to install http-proxy-middleware as dependencies not dev-dependencies in the future.

Many apps, including me, are using http-proxy-middleware in production.

So, it can cause a lot of confusion if READMD.md installation guide is instructed to install http-proxy-middleware as dev-dependencies.

I hope that PR has been merged to reduce confusion.