### PR TITLE
chore: show async response header

### DIFF
--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -12,14 +12,14 @@ const myProxy = createProxyMiddleware({
     proxyReq.setHeader('mpth-1', 'da');
   },
   onProxyRes: async (proxyRes, req, res) => {
-    const bar = await new Promise((resolve, reject) => {
+    const da = await new Promise((resolve, reject) => {
       setTimeout(() => {
-        resolve({ wei: 'da' });
+        resolve({ wei: 'wei' });
       }, 200);
     });
 
     // add your dynamic header
-    res.setHeader('mpth-2', bar.wei);
+    res.setHeader('mpth-2', da.wei);
 
     // now pipe the response
     proxyRes.pipe(res);
@@ -29,7 +29,7 @@ const myProxy = createProxyMiddleware({
 app.use('/api', myProxy);
 ```
 
-There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy or by making onProxyReq async as well. Like:
+There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy. Like:
 
 ```javascript
 const entryMiddleware = async (req, res, next) => {
@@ -56,14 +56,14 @@ const myProxy = createProxyMiddleware({
     proxyReq.setHeader('mpth-1', req.locals.da);
   },
   onProxyRes: async (proxyRes, req, res) => {
-    const bar = await new Promise((resolve, reject) => {
+    const da = await new Promise((resolve, reject) => {
       setTimeout(() => {
-        resolve({ wei: 'da' });
+        resolve({ wei: 'wei' });
       }, 200);
     });
 
     // end:
-    res.setHeader('mpth-2', bar.wei);
+    res.setHeader('mpth-2', da.wei);
 
     proxyRes.pipe(res);
   },

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -1,0 +1,89 @@
+# Async proxied response
+
+Sometimes we need the ability to modify the response headers of the response of the proxied backend before sending it. For achieving it just make sure you have selfHandleResponse to true and add a pipe in the proxyRes:
+
+```javascript
+
+const myProxy = createProxyMiddleware({
+  target: 'http://www.example.com',
+  changeOrigin: true,
+    selfHandleResponse: true,
+    onProxyReq: (proxyReq, req, res) => {
+      // before
+      proxyReq.setHeader('mpth-1', 'da');
+    },
+    onProxyRes: async (proxyRes, req, res) => {
+
+      const bar = await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve({ 'wei': 'da' });
+        }, 200);
+      });
+
+      // add your dynamic header
+      res.setHeader('mpth-2', bar.wei);
+
+      // now pipe the response
+      proxyRes.pipe(res);
+
+    }  
+});
+
+app.use(
+  '/api',
+  myProxy,
+);
+```
+
+There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy. Like:
+
+
+
+```javascript
+
+const entryMiddleware = async (req,res,next) => {
+  const foo = await new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({ 'da': 'da' });
+    }, 200);
+  });
+  req.locals = {
+    da: foo.da
+  }
+  next();
+};
+
+const myProxy = createProxyMiddleware({
+  target: 'http://www.example.com',
+  changeOrigin: true,
+  selfHandleResponse: true,
+  onProxyReq: (proxyReq, req, res) => {
+    // before
+    // get something async from entry middlware before the proxy kicks in
+    console.log('proxyReq:', req.locals.da);
+    
+    proxyReq.setHeader('mpth-1', req.locals.da);
+  },
+  onProxyRes: async (proxyRes, req, res) => {
+
+    const bar = await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve({ 'wei': 'da' });
+      }, 200);
+    });
+
+    // end:
+    res.setHeader('mpth-2', bar.wei);
+
+    proxyRes.pipe(res);
+
+  }  
+});
+
+
+app.use(
+  '/api',
+  entryMiddleware,
+  myProxy,
+);
+```

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -3,53 +3,44 @@
 Sometimes we need the ability to modify the response headers of the response of the proxied backend before sending it. For achieving it just make sure you have selfHandleResponse to true and add a pipe in the proxyRes:
 
 ```javascript
-
 const myProxy = createProxyMiddleware({
   target: 'http://www.example.com',
   changeOrigin: true,
-    selfHandleResponse: true,
-    onProxyReq: (proxyReq, req, res) => {
-      // before
-      proxyReq.setHeader('mpth-1', 'da');
-    },
-    onProxyRes: async (proxyRes, req, res) => {
+  selfHandleResponse: true,
+  onProxyReq: (proxyReq, req, res) => {
+    // before
+    proxyReq.setHeader('mpth-1', 'da');
+  },
+  onProxyRes: async (proxyRes, req, res) => {
+    const bar = await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve({ wei: 'da' });
+      }, 200);
+    });
 
-      const bar = await new Promise((resolve, reject) => {
-        setTimeout(() => {
-          resolve({ 'wei': 'da' });
-        }, 200);
-      });
+    // add your dynamic header
+    res.setHeader('mpth-2', bar.wei);
 
-      // add your dynamic header
-      res.setHeader('mpth-2', bar.wei);
-
-      // now pipe the response
-      proxyRes.pipe(res);
-
-    }  
+    // now pipe the response
+    proxyRes.pipe(res);
+  },
 });
 
-app.use(
-  '/api',
-  myProxy,
-);
+app.use('/api', myProxy);
 ```
 
 There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy. Like:
 
-
-
 ```javascript
-
-const entryMiddleware = async (req,res,next) => {
+const entryMiddleware = async (req, res, next) => {
   const foo = await new Promise((resolve, reject) => {
     setTimeout(() => {
-      resolve({ 'da': 'da' });
+      resolve({ da: 'da' });
     }, 200);
   });
   req.locals = {
-    da: foo.da
-  }
+    da: foo.da,
+  };
   next();
 };
 
@@ -61,14 +52,13 @@ const myProxy = createProxyMiddleware({
     // before
     // get something async from entry middlware before the proxy kicks in
     console.log('proxyReq:', req.locals.da);
-    
+
     proxyReq.setHeader('mpth-1', req.locals.da);
   },
   onProxyRes: async (proxyRes, req, res) => {
-
     const bar = await new Promise((resolve, reject) => {
       setTimeout(() => {
-        resolve({ 'wei': 'da' });
+        resolve({ wei: 'da' });
       }, 200);
     });
 
@@ -76,14 +66,8 @@ const myProxy = createProxyMiddleware({
     res.setHeader('mpth-2', bar.wei);
 
     proxyRes.pipe(res);
-
-  }  
+  },
 });
 
-
-app.use(
-  '/api',
-  entryMiddleware,
-  myProxy,
-);
+app.use('/api', entryMiddleware, myProxy);
 ```

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -29,7 +29,7 @@ const myProxy = createProxyMiddleware({
 app.use('/api', myProxy);
 ```
 
-There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy. Like:
+There are also cases where you need to modify the request header async, we can achieve this by applying middleware in front of the proxy or by making onProxyReq async as well. Like:
 
 ```javascript
 const entryMiddleware = async (req, res, next) => {

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -71,3 +71,5 @@ const myProxy = createProxyMiddleware({
 
 app.use('/api', entryMiddleware, myProxy);
 ```
+
+_working sample available at: [codesandbox.io/s/holy-resonance-yz552](https://codesandbox.io/s/holy-resonance-yz552?file=/src/index.js)_

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -72,4 +72,4 @@ const myProxy = createProxyMiddleware({
 app.use('/api', entryMiddleware, myProxy);
 ```
 
-_working sample available at: [codesandbox.io/s/holy-resonance-yz552](https://codesandbox.io/s/holy-resonance-yz552?file=/src/index.js)_
+_working sample available at: [codesandbox.io/s/holy-resonance-yz552](https://codesandbox.io/s/holy-resonance-yz552?file=/src/index.js) Server Control Panel: restart server, see logging_


### PR DESCRIPTION
Steven mergen deze handel :)

this solves #318 about async handling proxied response. I can now modify the response before piping it, and im able to set response headers before i actually sent the response. It was all in the lib itself, so native no tricks :)

if you want to check the flow here is the working example:

https://codesandbox.io/s/holy-resonance-yz552?file=/src/index.js

controller: restart server, now you will see this flow:

```
[HPM] Proxy created: /  -> http://localhost:3001
🚀 dummy service started on 3001
🚀 proxy started on 8080
proxyReq - test entry async is provided: da
target - async request header: da
onProxyRes
test - start: 200
test - response header: wei
test - end: { baba: 'yaga' }
```

the "wei" in the response header is set async and this validates it works :)

~~if needed i can put the link in the recipe?~~ done
