### PR TITLE
feat: try to proxy body even after body-parser middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ _All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#option
   - [app.use\(path, proxy\)](#appusepath-proxy)
 - [WebSocket](#websocket)
   - [External WebSocket upgrade](#external-websocket-upgrade)
+- [Intercept and manipulate requests](#intercept-and-manipulate-requests)
 - [Intercept and manipulate responses](#intercept-and-manipulate-responses)
 - [Working examples](#working-examples)
 - [Recipes](#recipes)
@@ -480,6 +481,25 @@ app.use(wsProxy);
 
 const server = app.listen(3000);
 server.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'
+```
+
+## Intercept and manipulate requests
+
+Intercept requests from downstream by defining `onProxyReq` in `createProxyMiddleware`.
+
+Currently the only pre-provided request interceptor is `fixRequestBody`, which is used to fix proxied POST requests when `bodyParser` is applied before this middleware.
+
+Example:
+
+```javascript
+const { createProxyMiddleware, fixRequestBody } = require('http-proxy-middleware');
+
+const proxy = createProxyMiddleware({
+  /**
+   * Fix bodyParser
+   **/
+  onProxyReq: fixRequestBody,
+});
 ```
 
 ## Intercept and manipulate responses

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/ws": "^7.4.0",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
+    "body-parser": "^1.19.0",
     "browser-sync": "^2.26.14",
     "connect": "^3.7.0",
     "eslint": "^7.23.0",

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -5,7 +5,7 @@ import * as querystring from 'querystring';
 /**
  * Fix proxied body if bodyParser is involved.
  */
-export function fixRequestBody(proxyReq: ClientRequest, req: Request) {
+export function fixRequestBody(proxyReq: ClientRequest, req: Request): void {
   if (!req.body || !Object.keys(req.body).length) {
     return;
   }

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -1,0 +1,26 @@
+import { ClientRequest } from 'http';
+import type { Request } from '../types';
+import * as querystring from 'querystring';
+
+/**
+ * Fix proxied body if bodyParser is involved.
+ */
+export function fixRequestBody(proxyReq: ClientRequest, req: Request) {
+  if (!req.body || !Object.keys(req.body).length) {
+    return;
+  }
+
+  const contentType = proxyReq.getHeader('Content-Type') as string;
+  const writeBody = (bodyData: string) => {
+    proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
+    proxyReq.write(bodyData);
+  };
+
+  if (contentType.includes('application/json')) {
+    writeBody(JSON.stringify(req.body));
+  }
+
+  if (contentType === 'application/x-www-form-urlencoded') {
+    writeBody(querystring.stringify(req.body));
+  }
+}

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -12,6 +12,7 @@ export function fixRequestBody(proxyReq: ClientRequest, req: Request): void {
 
   const contentType = proxyReq.getHeader('Content-Type') as string;
   const writeBody = (bodyData: string) => {
+    // deepcode ignore ContentLengthInCode: bodyParser fix
     proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
     proxyReq.write(bodyData);
   };

--- a/src/handlers/public.ts
+++ b/src/handlers/public.ts
@@ -1,1 +1,2 @@
 export { responseInterceptor } from './response-interceptor';
+export { fixRequestBody } from './fix-request-body';

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -1,10 +1,8 @@
-import { ClientRequest } from 'http';
 import type * as https from 'https';
 import type * as express from 'express';
 import type { Filter, Request, RequestHandler, Response, Options } from './types';
 import * as httpProxy from 'http-proxy';
 import { createConfig, Config } from './config-factory';
-import * as querystring from 'querystring';
 import * as contextMatcher from './context-matcher';
 import * as handlers from './_handlers';
 import { getArrow, getInstance } from './logger';
@@ -34,9 +32,6 @@ export class HttpProxyMiddleware {
 
     // log errors for debug purpose
     this.proxy.on('error', this.logError);
-
-    // fix proxied body if bodyParser is involved
-    this.proxy.on('proxyReq', this.fixBody);
 
     // https://github.com/chimurai/http-proxy-middleware/issues/19
     // expose function to upgrade externally
@@ -197,25 +192,5 @@ export class HttpProxyMiddleware {
     const errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors'; // link to Node Common Systems Errors page
 
     this.logger.error(errorMessage, requestHref, targetHref, err.code || err, errReference);
-  };
-
-  private fixBody = (proxyReq: ClientRequest, req: Request) => {
-    if (!req.body || !Object.keys(req.body).length) {
-      return;
-    }
-
-    const contentType = proxyReq.getHeader('Content-Type') as string;
-    const writeBody = (bodyData: string) => {
-      proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-      proxyReq.write(bodyData);
-    };
-
-    if (contentType.includes('application/json')) {
-      writeBody(JSON.stringify(req.body));
-    }
-
-    if (contentType === 'application/x-www-form-urlencoded') {
-      writeBody(querystring.stringify(req.body));
-    }
   };
 }

--- a/test/e2e/_utils.ts
+++ b/test/e2e/_utils.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import { Express, RequestHandler } from 'express';
 
-export { createProxyMiddleware, responseInterceptor } from '../../dist/index';
+export { createProxyMiddleware, responseInterceptor, fixRequestBody } from '../../dist/index';
 
 export function createApp(...middleware: RequestHandler[]): Express {
   const app = express();

--- a/test/e2e/_utils.ts
+++ b/test/e2e/_utils.ts
@@ -3,9 +3,9 @@ import { Express, RequestHandler } from 'express';
 
 export { createProxyMiddleware, responseInterceptor } from '../../dist/index';
 
-export function createApp(middleware: RequestHandler): Express {
+export function createApp(...middleware: RequestHandler[]): Express {
   const app = express();
-  app.use(middleware);
+  app.use(...middleware);
   return app;
 }
 

--- a/test/e2e/_utils.ts
+++ b/test/e2e/_utils.ts
@@ -3,9 +3,9 @@ import { Express, RequestHandler } from 'express';
 
 export { createProxyMiddleware, responseInterceptor, fixRequestBody } from '../../dist/index';
 
-export function createApp(...middleware: RequestHandler[]): Express {
+export function createApp(...middlewares: RequestHandler[]): Express {
   const app = express();
-  app.use(...middleware);
+  app.use(...middlewares);
   return app;
 }
 

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -1,4 +1,4 @@
-import { createProxyMiddleware, createApp, createAppWithPath } from './_utils';
+import { createProxyMiddleware, createApp, createAppWithPath, fixRequestBody } from './_utils';
 import * as request from 'supertest';
 import { Mockttp, getLocal, CompletedRequest } from 'mockttp';
 import { Request, Response } from '../../src/types';
@@ -86,6 +86,7 @@ describe('E2E http-proxy-middleware', () => {
             bodyParser.urlencoded({ extended: false }),
             createProxyMiddleware('/api', {
               target: `http://localhost:${mockTargetServer.port}`,
+              onProxyReq: fixRequestBody,
             })
           )
         );
@@ -102,6 +103,7 @@ describe('E2E http-proxy-middleware', () => {
             bodyParser.json(),
             createProxyMiddleware('/api', {
               target: `http://localhost:${mockTargetServer.port}`,
+              onProxyReq: fixRequestBody,
             })
           )
         );

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -99,7 +99,7 @@ describe('E2E http-proxy-middleware', () => {
       it('should proxy request body from json', async () => {
         agent = request(
           createApp(
-            bodyParser.urlencoded({ extended: false }),
+            bodyParser.json(),
             createProxyMiddleware('/api', {
               target: `http://localhost:${mockTargetServer.port}`,
             })

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -90,8 +90,8 @@ describe('E2E http-proxy-middleware', () => {
           )
         );
 
-        await mockTargetServer.post('/api').thenCallback((request) => {
-          expect(request.body.text).toBe('foo=bar&bar=baz');
+        await mockTargetServer.post('/api').thenCallback((req) => {
+          expect(req.body.text).toBe('foo=bar&bar=baz');
           return { status: 200 };
         });
         await agent.post('/api').send('foo=bar').send('bar=baz').expect(200);
@@ -106,8 +106,8 @@ describe('E2E http-proxy-middleware', () => {
           )
         );
 
-        await mockTargetServer.post('/api').thenCallback((request) => {
-          expect(request.body.json).toEqual({ foo: 'bar', bar: 'baz' });
+        await mockTargetServer.post('/api').thenCallback((req) => {
+          expect(req.body.json).toEqual({ foo: 'bar', bar: 'baz' });
           return { status: 200 };
         });
         await agent.post('/api').send({ foo: 'bar', bar: 'baz' }).expect(200);

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -97,6 +97,7 @@ describe('E2E http-proxy-middleware', () => {
         });
         await agent.post('/api').send('foo=bar').send('bar=baz').expect(200);
       });
+
       it('should proxy request body from json', async () => {
         agent = request(
           createApp(
@@ -109,10 +110,10 @@ describe('E2E http-proxy-middleware', () => {
         );
 
         await mockTargetServer.post('/api').thenCallback((req) => {
-          expect(req.body.json).toEqual({ foo: 'bar', bar: 'baz' });
+          expect(req.body.json).toEqual({ foo: 'bar', bar: 'baz', doubleByte: '文' });
           return { status: 200 };
         });
-        await agent.post('/api').send({ foo: 'bar', bar: 'baz' }).expect(200);
+        await agent.post('/api').send({ foo: 'bar', bar: 'baz', doubleByte: '文' }).expect(200);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,7 +1483,7 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-body-parser@1.19.0, body-parser@^1.15.2:
+body-parser@1.19.0, body-parser@^1.15.2, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
If a body parser middleware is added before the proxy is configured, proxying POST requests with bodies fails. This fixes that and provides a test, as requested by @chimurai in #460.

Code from #460 by @sarumont and from #320 by @repl-chris used -- thanks to both!

Fixes #90
Fixes #320
Fixes #417