### PR TITLE
refactor: replace lodash with small libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/express": "^4.17.3",
     "@types/is-glob": "^4.0.1",
     "@types/jest": "^26.0.22",
-    "@types/lodash": "^4.14.168",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.14.37",
     "@types/supertest": "^2.0.10",
@@ -79,9 +78,10 @@
   },
   "dependencies": {
     "@types/http-proxy": "^1.17.5",
+    "camelcase": "^6.2.0",
     "http-proxy": "^1.18.1",
     "is-glob": "^4.0.1",
-    "lodash": "^4.17.21",
+    "is-plain-obj": "^3.0.0",
     "micromatch": "^4.0.2"
   },
   "engines": {

--- a/src/config-factory.ts
+++ b/src/config-factory.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isPlainObj = require('is-plain-obj');
 import * as url from 'url';
 import { ERRORS } from './errors';
 import { getInstance } from './logger';
@@ -74,7 +74,7 @@ function isStringShortHand(context: Filter) {
  * @return {Boolean}         [description]
  */
 function isContextless(context: Filter, opts: Options) {
-  return _.isPlainObject(context) && (opts == null || Object.keys(opts).length === 0);
+  return isPlainObj(context) && (opts == null || Object.keys(opts).length === 0);
 }
 
 function configureLogger(options: Options) {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import camelcase = require('camelcase');
 import { getInstance } from './logger';
 const logger = getInstance();
 
@@ -21,7 +21,7 @@ export function getHandlers(options) {
     // all handlers for the http-proxy events are prefixed with 'on'.
     // loop through options and try to find these handlers
     // and add them to the handlers object for subscription in init().
-    const eventName = _.camelCase('on ' + event);
+    const eventName = camelcase('on ' + event);
     const fnHandler = options ? options[eventName] : null;
 
     if (typeof fnHandler === 'function') {

--- a/src/path-rewriter.ts
+++ b/src/path-rewriter.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isPlainObj = require('is-plain-obj');
 import { ERRORS } from './errors';
 import { getInstance } from './logger';
 const logger = getInstance();
@@ -42,13 +42,9 @@ export function createPathRewriter(rewriteConfig) {
 function isValidRewriteConfig(rewriteConfig) {
   if (typeof rewriteConfig === 'function') {
     return true;
-  } else if (_.isPlainObject(rewriteConfig) && Object.keys(rewriteConfig).length !== 0) {
-    return true;
-  } else if (
-    rewriteConfig === undefined ||
-    rewriteConfig === null ||
-    _.isEqual(rewriteConfig, {})
-  ) {
+  } else if (isPlainObj(rewriteConfig)) {
+    return Object.keys(rewriteConfig).length !== 0;
+  } else if (rewriteConfig === undefined || rewriteConfig === null) {
     return false;
   } else {
     throw new Error(ERRORS.ERR_PATH_REWRITER_CONFIG);
@@ -58,7 +54,7 @@ function isValidRewriteConfig(rewriteConfig) {
 function parsePathRewriteRules(rewriteConfig) {
   const rules = [];
 
-  if (_.isPlainObject(rewriteConfig)) {
+  if (isPlainObj(rewriteConfig)) {
     for (const [key] of Object.entries(rewriteConfig)) {
       rules.push({
         regex: new RegExp(key),

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isPlainObj = require('is-plain-obj');
 import { getInstance } from './logger';
 const logger = getInstance();
 
@@ -6,7 +6,7 @@ export async function getTarget(req, config) {
   let newTarget;
   const router = config.router;
 
-  if (_.isPlainObject(router)) {
+  if (isPlainObj(router)) {
     newTarget = getTargetFromProxyTable(req, router);
   } else if (typeof router === 'function') {
     newTarget = await router(req);

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,11 +902,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/lodash@^4.14.168":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
-
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -1704,6 +1699,11 @@ camelcase@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
+
+camelcase@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3616,6 +3616,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
`camelcase` and `is-plain-obj` are small, single purpose and
dependency free utilities with builtin TS support. They cover all
left lodash usages.