### PR TITLE
fix(proxy): close proxy when server closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+- fix(proxy): close proxy when server closes ([#508](https://github.com/chimurai/http-proxy-middleware/pull/508))
+- refactor(lodash): remove lodash ([#459](https://github.com/chimurai/http-proxy-middleware/pull/459)) ([#507](https://github.com/chimurai/http-proxy-middleware/pull/507)) ([TrySound](https://github.com/TrySound))
+- fix(ETIMEDOUT): return 504 on ETIMEDOUT ([#480](https://github.com/chimurai/http-proxy-middleware/pull/480)) ([aremishevsky](https://github.com/aremishevsky))
+
 ## [v1.0.6](https://github.com/chimurai/http-proxy-middleware/releases/tag/v1.0.6)
 
 - chore(deps): lodash 4.17.20 ([#475](https://github.com/chimurai/http-proxy-middleware/pull/475))

--- a/test/e2e/express-router.spec.ts
+++ b/test/e2e/express-router.spec.ts
@@ -4,8 +4,8 @@ import { createProxyMiddleware } from './_utils';
 import { Options } from '../../src/index';
 
 describe('Usage in Express', () => {
-  let app;
-  let server;
+  let app: express.Express;
+  let server: http.Server;
 
   beforeEach(() => {
     app = express();
@@ -46,6 +46,7 @@ describe('Usage in Express', () => {
       server = app.listen(3000);
     });
 
+    // FIXME: flaky e2e test; caused by fixed port:3000
     it('should still return a response when route does not match proxyConfig', (done) => {
       let responseBody;
       http.get('http://localhost:3000/sub/hello', (res) => {

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -382,11 +382,12 @@ describe('E2E http-proxy-middleware', () => {
     });
 
     describe('option.logLevel & option.logProvider', () => {
-      let logMessage;
+      let logMessages: string[];
 
       beforeEach(() => {
-        const customLogger = (message) => {
-          logMessage = message;
+        logMessages = [];
+        const customLogger = (message: string) => {
+          logMessages.push(message);
         };
 
         agent = request(
@@ -406,9 +407,12 @@ describe('E2E http-proxy-middleware', () => {
         await mockTargetServer.get('/api/foo/bar').thenReply(200);
         await agent.get(`/api/foo/bar`).expect(200);
 
-        expect(logMessage).toMatchInlineSnapshot(
-          `"[HPM] Proxy created: /api  -> http://localhost:8000"`
-        );
+        expect(logMessages).toMatchInlineSnapshot(`
+          Array [
+            "[HPM] Proxy created: /api  -> http://localhost:8000",
+            "[HPM] server close signal received: closing proxy server",
+          ]
+        `);
       });
     });
   });


### PR DESCRIPTION
fixes #189 
fixes #287

Example Graceful Shutdown (source: [https://expressjs.com](https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html)):

```js
process.on('SIGTERM', () => {
  debug('SIGTERM signal received: closing HTTP server')
  server.close(() => {
    debug('HTTP server closed')
  })
})
```

More on graceful server shutdown: https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html