### PR TITLE
fix(option): optional `target` when `router` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- fix(option): optional `target` when `router` is used ([#512](https://github.com/chimurai/http-proxy-middleware/pull/512))
+
 ## [v1.1.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v1.1.0)
 
 - fix(errorHandler): fix confusing error message ([#509](https://github.com/chimurai/http-proxy-middleware/pull/509))

--- a/src/config-factory.ts
+++ b/src/config-factory.ts
@@ -6,9 +6,11 @@ import { Filter, Options } from './types';
 
 const logger = getInstance();
 
-export function createConfig(context, opts?) {
+export type Config = { context: Filter; options: Options };
+
+export function createConfig(context, opts?: Options): Config {
   // structure of config object to be returned
-  const config = {
+  const config: Config = {
     context: undefined,
     options: {} as Options,
   };
@@ -38,7 +40,7 @@ export function createConfig(context, opts?) {
 
   configureLogger(config.options);
 
-  if (!config.options.target) {
+  if (!config.options.target && !config.options.router) {
     throw new Error(ERRORS.ERR_CONFIG_FACTORY_TARGET_MISSING);
   }
 

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -1,7 +1,7 @@
 import * as https from 'https';
 import * as express from 'express';
 import * as httpProxy from 'http-proxy';
-import { createConfig } from './config-factory';
+import { createConfig, Config } from './config-factory';
 import * as contextMatcher from './context-matcher';
 import * as handlers from './handlers';
 import { getArrow, getInstance } from './logger';
@@ -11,7 +11,7 @@ import { Filter, Request, RequestHandler, Response, Options } from './types';
 
 export class HttpProxyMiddleware {
   private logger = getInstance();
-  private config;
+  private config: Config;
   private wsInternalSubscribed = false;
   private serverOnCloseSubscribed = false;
   private proxyOptions: Options;

--- a/test/unit/config-factory.spec.ts
+++ b/test/unit/config-factory.spec.ts
@@ -136,8 +136,24 @@ describe('configFactory', () => {
         };
       });
 
-      it('should throw an error when target option is missing', () => {
+      it('should throw an error when target and router option are missing', () => {
         expect(fn).toThrowError(Error);
+      });
+    });
+
+    describe('optional option.target when option.router is used', () => {
+      let fn;
+
+      beforeEach(() => {
+        fn = () => {
+          createConfig('/api', {
+            router: (req) => 'http://www.example.com',
+          });
+        };
+      });
+
+      it('should not throw an error when target option is missing when router is used', () => {
+        expect(fn).not.toThrowError(Error);
       });
     });
 


### PR DESCRIPTION
fixes #448