### PR TITLE
fix(error handler): re-throw http-proxy missing target error

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -54,6 +54,11 @@ export function getHandlers(options: Options) {
 }
 
 function defaultErrorHandler(err, req: express.Request, res: express.Response) {
+  // Re-throw error. Not recoverable since req & res are empty.
+  if (!req && !res) {
+    throw err; // "Error: Must provide a proper URL as target"
+  }
+
   const host = req.headers && req.headers.host;
   const code = err.code;
 

--- a/test/unit/handlers.spec.ts
+++ b/test/unit/handlers.spec.ts
@@ -133,4 +133,11 @@ describe('default proxy error handler', () => {
     proxyError(mockError, mockReq, mockRes, proxyOptions);
     expect(errorMessage).toBe('Error occured while trying to proxy: localhost:3000/api');
   });
+
+  it('should re-throw error from http-proxy when target is missing', () => {
+    mockRes.headersSent = true;
+    const error = new Error('Must provide a proper URL as target');
+    const fn = () => proxyError(error, undefined, undefined, proxyOptions);
+    expect(fn).toThrowError(error);
+  });
 });


### PR DESCRIPTION
Background:
With `router` usage and optional `target` (#512); Required `target` for http-proxy can sometimes be empty.

This PR will re-throw the error emitted from `http-proxy`.

`req` and `res` object are empty, so there is no graceful way to handle this error...

In these cases  it recommended to set `target` as fallback.
