### PR TITLE
[FEATURE] If available return error message

### DIFF
--- a/src/_handlers.ts
+++ b/src/_handlers.ts
@@ -79,7 +79,7 @@ function defaultErrorHandler(err, req: express.Request, res: express.Response) {
     }
   }
 
-  res.end(`Error occured while trying to proxy: ${host}${req.url}`);
+  res.end(`Error ${err.message || 'occured'} while trying to proxy: ${host}${req.url}`);
 }
 
 function logClose(req, socket, head) {


### PR DESCRIPTION
Was trying to hunt down the reason my proxy kept failing and all I was getting was:

```Error occured while trying to proxy: [proxy url]```

Actual reason was expired certificate and if err was displayed it would have been show as such.

ex. ```Error certificate has expired while trying to proxy: [proxy url]```

