### PR TITLE
chore(typescript): extract handlers types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import type * as express from 'express';
 import type * as http from 'http';
 import type * as httpProxy from 'http-proxy';
 import type * as net from 'net';
+import type * as url from 'url';
 
 export interface Request extends express.Request {}
 export interface Response extends express.Response {}
@@ -51,24 +52,38 @@ type Logger = (...args: any[]) => void;
 
 export type LogProviderCallback = (provider: LogProvider) => LogProvider;
 
-export type OnErrorCallback = (err: Error, req: Request, res: Response) => void;
+/**
+ * Use types based on the events listeners from http-proxy
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/51504fd999031b7f025220fab279f1b2155cbaff/types/http-proxy/index.d.ts
+ */
+export type OnErrorCallback = (
+  err: Error,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  target?: string | Partial<url.Url>
+) => void;
 export type OnProxyResCallback = (
   proxyRes: http.IncomingMessage,
-  req: Request,
-  res: Response
+  req: http.IncomingMessage,
+  res: http.ServerResponse
 ) => void;
 export type OnProxyReqCallback = (
   proxyReq: http.ClientRequest,
-  req: Request,
-  res: Response
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  options: httpProxy.ServerOptions
 ) => void;
 export type OnProxyReqWsCallback = (
   proxyReq: http.ClientRequest,
-  req: Request,
+  req: http.IncomingMessage,
   socket: net.Socket,
   options: httpProxy.ServerOptions,
   head: any
 ) => void;
-export type OnCloseCallback = (res: Response, socket: net.Socket, head: any) => void;
+export type OnCloseCallback = (
+  proxyRes: http.IncomingMessage,
+  proxySocket: net.Socket,
+  proxyHead: any
+) => void;
 
 export type OnOpenCallback = (proxySocket: net.Socket) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,20 +29,14 @@ export interface Options extends httpProxy.ServerOptions {
     | ((req: Request) => httpProxy.ServerOptions['target'])
     | ((req: Request) => Promise<httpProxy.ServerOptions['target']>);
   logLevel?: 'debug' | 'info' | 'warn' | 'error' | 'silent';
-  logProvider?(provider: LogProvider): LogProvider;
+  logProvider?: LogProviderCallback;
 
-  onError?(err: Error, req: Request, res: Response): void;
-  onProxyRes?(proxyRes: http.IncomingMessage, req: Request, res: Response): void;
-  onProxyReq?(proxyReq: http.ClientRequest, req: Request, res: Response): void;
-  onProxyReqWs?(
-    proxyReq: http.ClientRequest,
-    req: Request,
-    socket: net.Socket,
-    options: httpProxy.ServerOptions,
-    head: any
-  ): void;
-  onOpen?(proxySocket: net.Socket): void;
-  onClose?(res: Response, socket: net.Socket, head: any): void;
+  onError?: OnErrorCallback;
+  onProxyRes?: OnProxyResCallback;
+  onProxyReq?: OnProxyReqCallback;
+  onProxyReqWs?: OnProxyReqWsCallback;
+  onOpen?: OnOpenCallback;
+  onClose?: OnCloseCallback;
 }
 
 interface LogProvider {
@@ -54,3 +48,27 @@ interface LogProvider {
 }
 
 type Logger = (...args: any[]) => void;
+
+export type LogProviderCallback = (provider: LogProvider) => LogProvider;
+
+export type OnErrorCallback = (err: Error, req: Request, res: Response) => void;
+export type OnProxyResCallback = (
+  proxyRes: http.IncomingMessage,
+  req: Request,
+  res: Response
+) => void;
+export type OnProxyReqCallback = (
+  proxyReq: http.ClientRequest,
+  req: Request,
+  res: Response
+) => void;
+export type OnProxyReqWsCallback = (
+  proxyReq: http.ClientRequest,
+  req: Request,
+  socket: net.Socket,
+  options: httpProxy.ServerOptions,
+  head: any
+) => void;
+export type OnCloseCallback = (res: Response, socket: net.Socket, head: any) => void;
+
+export type OnOpenCallback = (proxySocket: net.Socket) => void;


### PR DESCRIPTION
I've been rewriting the handlers' types on my current project. To avoid it this PR extract handlers type and expose them

Also made the callbacks have the same types implemented on the [http-proxy](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/51504fd999031b7f025220fab279f1b2155cbaff/types/http-proxy/index.d.ts)