### PR TITLE
Move @types/express to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
-    "@types/express": "^4.17.13",
     "@types/is-glob": "^4.0.2",
     "@types/jest": "^27.0.2",
     "@types/micromatch": "^4.0.2",
@@ -83,6 +82,7 @@
     "ws": "^8.2.3"
   },
   "dependencies": {
+    "@types/express": "^4.17.13",
     "@types/http-proxy": "^1.17.5",
     "http-proxy": "^1.18.1",
     "is-glob": "^4.0.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The outputted types depend on `@types/express` in `types.d.ts` and therefore the package should have a dependency on `@types/express` instead of just a devDependency.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without the dependency it causes this error:
```
../../.yarn/cache/http-proxy-middleware-npm-2.0.1-d5d4a98393-0de65bc664.zip/node_modules/http-proxy-middleware/dist/types.d.ts:6:31 - error TS2307: Cannot find module 'express' or its corresponding type declarations.

6 import type * as express from 'express';
                                ~~~~~~~~~


Found 1 error.
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
