### PR TITLE
Expose HTTP Proxy middleware, so it can be used outside express

### DIFF
--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -43,7 +43,7 @@ export class HttpProxyMiddleware {
   }
 
   // https://github.com/Microsoft/TypeScript/wiki/'this'-in-TypeScript#red-flags-for-this
-  public middleware: RequestHandler = async (
+  public middleware: any = async (
     req: Request,
     res: Response,
     next: express.NextFunction

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export function createProxyMiddleware(context: Filter | Options, options?: Optio
 }
 
 export * from './handlers';
+export * from './http-proxy-middleware';
 
 export { Filter, Options, RequestHandler } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ export function createProxyMiddleware(context: Filter | Options, options?: Optio
   return middleware;
 }
 
+export function createProxy(context: Filter | Options, options?: Options) {
+  return new HttpProxyMiddleware(context, options);
+}
+
 export * from './handlers';
 export * from './http-proxy-middleware';
 


### PR DESCRIPTION
The purpose of this PR is to make it possible to use the middleware outside Express. For example we integrated the library with NestJS using `NestMiddleware` and Fastify.

## Description

This requires the change of `middleware` type to `any` (since there are no internal defined types that can be used instead for now). Additional method `createProxy` is added, which returns `HttpProxyMiddleware`, thus exposing the `middleware` directly, giving a bit more flexibility.

## Motivation and Context

The only exposed method returns an Express `RequestHandler` object, which TypeScript does not recognize as callable in NestJS environment. Changing this to `any` allows it to be called from TypeScript.

## How has this been tested?

Has been tested by deploying to internal servers and thoroughly connected with NestJS.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The change is backward compatible and does not break any code.
