### PR TITLE
docs(response-interceptor.md): add headers modification example

### DIFF
--- a/recipes/response-interceptor.md
+++ b/recipes/response-interceptor.md
@@ -144,11 +144,11 @@ const proxy = createProxyMiddleware({
   selfHandleResponse: true, // res.end() will be called internally by responseInterceptor()
 
   /**
-   * Intercept response and remove the 
+   * Intercept response and remove the
    **/
   onProxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
     res.removeHeader('content-security-policy'); // Remove the Content Security Policy header
-    res.setHeader('HPM-Header', 'Intercepted by HPM') // Set a new header and value
+    res.setHeader('HPM-Header', 'Intercepted by HPM'); // Set a new header and value
   }),
 });
 ```

--- a/recipes/response-interceptor.md
+++ b/recipes/response-interceptor.md
@@ -128,3 +128,27 @@ const proxy = createProxyMiddleware({
 
 // http://localhost:3000/wikipedia/en/7/7d/Lenna\_%28test_image%29.png
 ```
+
+## Manipulate response headers
+
+```js
+const { createProxyMiddleware, responseInterceptor } = require('http-proxy-middleware');
+
+const proxy = createProxyMiddleware({
+  target: 'http://www.example.com',
+  changeOrigin: true, // for vhosted sites
+
+  /**
+   * IMPORTANT: avoid res.end being called automatically
+   **/
+  selfHandleResponse: true, // res.end() will be called internally by responseInterceptor()
+
+  /**
+   * Intercept response and remove the 
+   **/
+  onProxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
+    res.removeHeader('content-security-policy'); // Remove the Content Security Policy header
+    res.setHeader('HPM-Header', 'Intercepted by HPM') // Set a new header and value
+  }),
+});
+```


### PR DESCRIPTION
An update to the responseInterceptor recipe to include modifying headers

## Description

The recipe file did not include an example for modifying headers.

## Motivation and Context

I was working on a proof of concept at my place of work, and trying to utilise http-proxy-middleware. I was struggling with modifying the response headers, the details in https://github.com/chimurai/http-proxy-middleware#http-proxy-events worked fine if you didn't want to use the response interceptor.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
