### PR TITLE
fix(fix-request-body): improve content type check

### DIFF
--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -23,7 +23,7 @@ export function fixRequestBody(proxyReq: http.ClientRequest, req: http.IncomingM
     writeBody(JSON.stringify(requestBody));
   }
 
-  if (contentType === 'application/x-www-form-urlencoded') {
+  if (contentType && contentType.includes('application/x-www-form-urlencoded')) {
     writeBody(querystring.stringify(requestBody));
   }
 }

--- a/test/unit/fix-request-body.spec.ts
+++ b/test/unit/fix-request-body.spec.ts
@@ -64,4 +64,18 @@ describe('fixRequestBody', () => {
     expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
     expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
   });
+
+  it('should write when body is not empty and Content-Type includes application/x-www-form-urlencoded', () => {
+    const proxyRequest = fakeProxyRequest();
+    proxyRequest.setHeader('content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
+
+    jest.spyOn(proxyRequest, 'setHeader');
+    jest.spyOn(proxyRequest, 'write');
+
+    fixRequestBody(proxyRequest, { body: { someField: 'some value' } } as Request);
+
+    const expectedBody = querystring.stringify({ someField: 'some value' });
+    expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
+    expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

It is common for POST request to have the content type: `application/x-www-form-urlencoded; charset=UTF-8`

The `charset` part can be set when you have a form with attribute `accept-charset="utf-8"`

I encountered this while using the `fixRequestBody` function and the content type check doesn't take the charset into account. 

![Screen Shot 2022-03-09 at 11 57 11 PM](https://user-images.githubusercontent.com/10948652/157614824-41064241-56e2-45ec-90ef-ddfa3b71fb64.png)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
