### PR TITLE
fix: server mounting [BREAKING CHANGE]

### DIFF
--- a/examples/connect/index.js
+++ b/examples/connect/index.js
@@ -9,7 +9,7 @@ const { createProxyMiddleware } = require('../../dist'); // require('http-proxy-
  * Configure proxy middleware
  */
 const jsonPlaceholderProxy = createProxyMiddleware({
-  target: 'http://jsonplaceholder.typicode.com',
+  target: 'http://jsonplaceholder.typicode.com/users',
   changeOrigin: true, // for vhosted sites, changes host header to match to target's host
   logLevel: 'debug',
 });

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -8,7 +8,7 @@ const { createProxyMiddleware } = require('../../dist'); // require('http-proxy-
  * Configure proxy middleware
  */
 const jsonPlaceholderProxy = createProxyMiddleware({
-  target: 'http://jsonplaceholder.typicode.com',
+  target: 'http://jsonplaceholder.typicode.com/users',
   changeOrigin: true, // for vhosted sites, changes host header to match to target's host
   logLevel: 'debug',
 });

--- a/recipes/async-response.md
+++ b/recipes/async-response.md
@@ -4,7 +4,7 @@ Sometimes we need the ability to modify the response headers of the response of 
 
 ```javascript
 const myProxy = createProxyMiddleware({
-  target: 'http://www.example.com',
+  target: 'http://www.example.com/api',
   changeOrigin: true,
   selfHandleResponse: true,
   onProxyReq: (proxyReq, req, res) => {
@@ -45,7 +45,7 @@ const entryMiddleware = async (req, res, next) => {
 };
 
 const myProxy = createProxyMiddleware({
-  target: 'http://www.example.com',
+  target: 'http://www.example.com/api',
   changeOrigin: true,
   selfHandleResponse: true,
   onProxyReq: (proxyReq, req, res) => {

--- a/recipes/basic.md
+++ b/recipes/basic.md
@@ -6,27 +6,19 @@ This example will create a basic proxy middleware.
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 const apiProxy = createProxyMiddleware({
-  pathFilter: '/api',
   target: 'http://localhost:3000',
+  changeOrigin: true,
 });
 ```
 
 ## Alternative configuration
 
-The proxy behavior of the following examples are **exactly** the same; Just different ways to configure it.
-
 ```javascript
-app.use(createProxyMiddleware('/api', { target: 'http://localhost:3000', changeOrigin: true }));
+app.use('/api', createProxyMiddleware({ target: 'http://localhost:3000/api', changeOrigin: true }));
 ```
 
 ```javascript
-app.use(createProxyMiddleware('http://localhost:3000/api', { changeOrigin: true }));
-```
-
-```javascript
-app.use('/api', createProxyMiddleware('http://localhost:3000', { changeOrigin: true }));
-```
-
-```javascript
-app.use('/api', createProxyMiddleware({ target: 'http://localhost:3000', changeOrigin: true }));
+app.use(
+  createProxyMiddleware({ target: 'http://localhost:3000', changeOrigin: true, pathFilter: '/api' })
+);
 ```

--- a/recipes/servers.md
+++ b/recipes/servers.md
@@ -26,14 +26,14 @@ https://github.com/expressjs/express
 const express = require('express');
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const apiProxy = createProxyMiddleware('/api', {
-  target: 'http://www.example.org',
+const apiProxy = createProxyMiddleware({
+  target: 'http://www.example.org/api',
   changeOrigin: true, // for vhosted sites
 });
 
 const app = express();
 
-app.use(apiProxy);
+app.use('/api', apiProxy);
 app.listen(3000);
 ```
 
@@ -48,13 +48,13 @@ const http = require('http');
 const connect = require('connect');
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const apiProxy = createProxyMiddleware('/api', {
-  target: 'http://www.example.org',
+const apiProxy = createProxyMiddleware({
+  target: 'http://www.example.org/api',
   changeOrigin: true, // for vhosted sites
 });
 
 const app = connect();
-app.use(apiProxy);
+app.use('/api', apiProxy);
 
 http.createServer(app).listen(3000);
 ```
@@ -88,6 +88,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   });
 }
 
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
 // curl http://localhost:3000/api/users
 ```
 
@@ -101,9 +107,10 @@ https://github.com/BrowserSync/browser-sync
 const browserSync = require('browser-sync').create();
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const apiProxy = createProxyMiddleware('/api', {
+const apiProxy = createProxyMiddleware({
   target: 'http://www.example.org',
   changeOrigin: true, // for vhosted sites
+  pathFilter: '/api',
 });
 
 browserSync.init({
@@ -226,9 +233,10 @@ As a `function`:
 ```javascript
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const apiProxy = createProxyMiddleware('/api', {
+const apiProxy = createProxyMiddleware({
   target: 'http://www.example.org',
   changeOrigin: true, // for vhosted sites
+  pathFilter: '/api',
 });
 
 grunt.initConfig({
@@ -262,9 +270,10 @@ gulp.task('connect', function () {
   connect.server({
     root: ['./app'],
     middleware: function (connect, opt) {
-      const apiProxy = createProxyMiddleware('/api', {
+      const apiProxy = createProxyMiddleware({
         target: 'http://www.example.org',
         changeOrigin: true, // for vhosted sites
+        pathFilter: '/api',
       });
 
       return [apiProxy];
@@ -284,9 +293,10 @@ https://github.com/BrowserSync/grunt-browser-sync
 ```javascript
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const apiProxy = createProxyMiddleware('/api', {
+const apiProxy = createProxyMiddleware({
   target: 'http://www.example.org',
   changeOrigin: true, // for vhosted sites
+  pathFilter: '/api',
 });
 
 grunt.initConfig({

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -100,8 +100,7 @@ export class HttpProxyMiddleware {
    * Determine whether request should be proxied.
    */
   private shouldProxy = (pathFilter: Filter, req: Request): boolean => {
-    const path = (req as Request<express.Request>).originalUrl || req.url;
-    return matchPathFilter(pathFilter, path, req);
+    return matchPathFilter(pathFilter, req.url, req);
   };
 
   /**
@@ -113,10 +112,6 @@ export class HttpProxyMiddleware {
    * @return {Object} proxy options
    */
   private prepareProxyRequest = async (req: Request) => {
-    // https://github.com/chimurai/http-proxy-middleware/issues/17
-    // https://github.com/chimurai/http-proxy-middleware/issues/94
-    req.url = (req as Request<express.Request>).originalUrl || req.url;
-
     // store uri before it gets rewritten for logging
     const originalPath = req.url;
     const newProxyOptions = Object.assign({}, this.proxyOptions);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,11 @@ export interface RequestHandler {
 export type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
 
 export interface Options extends httpProxy.ServerOptions {
+  /**
+   * Narrow down requests to proxy or not.
+   * Filter on {@link http.IncomingMessage.url `pathname`} which is relative to the proxy's "mounting" point in the server.
+   * Or use the {@link http.IncomingMessage `req`}  object for more complex filtering.
+   */
   pathFilter?: Filter;
   pathRewrite?:
     | { [regexp: string]: string }

--- a/test/e2e/http-proxy-middleware.spec.ts
+++ b/test/e2e/http-proxy-middleware.spec.ts
@@ -18,10 +18,9 @@ describe('E2E http-proxy-middleware', () => {
 
   describe('pathFilter matching', () => {
     describe('do not proxy', () => {
-      const mockReq: Request<express.Request> = {
+      const mockReq: Request = {
         url: '/foo/bar',
-        originalUrl: '/foo/bar',
-      } as Request<express.Request>;
+      } as Request;
       const mockRes: Response = {} as Response;
       const mockNext: express.NextFunction = jest.fn();
 
@@ -410,7 +409,7 @@ describe('E2E http-proxy-middleware', () => {
         agent = request(
           createAppWithPath(
             '/api',
-            createProxyMiddleware({ target: `http://localhost:${mockTargetServer.port}` })
+            createProxyMiddleware({ target: `http://localhost:${mockTargetServer.port}/api` })
           )
         );
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes incorrect usage of `originalUrl`. Introduced in https://github.com/chimurai/http-proxy-middleware/pull/18

Now you can modify the `baseUrl`; a feature which Express' `app.use` already provides..

```js
// mount on "/users" and keep the "/users" base path
app.use('/user', createProxyMiddleware({'target': 'https://jsonplaceholder.typicode.com/users'}))


// mount on "/users" and change the "/users" base path
app.use('/user', createProxyMiddleware({'target': 'https://jsonplaceholder.typicode.com/customers'}))

```

## Motivation and Context

- https://github.com/chimurai/http-proxy-middleware/issues/225#issuecomment-351230574
- https://github.com/chimurai/http-proxy-middleware/discussions/541
- https://github.com/chimurai/http-proxy-middleware/pull/723#issuecomment-1068529477
- https://github.com/expressjs/express/issues/4854#issuecomment-1066171160

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

- Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
