### PR TITLE
feat(plugins): add support for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#option
   - [`pathFilter` (string, []string, glob, []glob, function)](#pathfilter-string-string-glob-glob-function)
   - [`pathRewrite` (object/function)](#pathrewrite-objectfunction)
   - [`router` (object/function)](#router-objectfunction)
+  - [`plugins` (Array)](#plugins-array)
   - [`logLevel` (string)](#loglevel-string)
   - [`logProvider` (function)](#logprovider-function)
 - [`http-proxy` events](#http-proxy-events)
@@ -268,6 +269,22 @@ router: async function(req) {
     const url = await doSomeIO();
     return url;
 }
+```
+
+### `plugins` (Array)
+
+```js
+const simpleRequestLogger = (proxy, options) => {
+  proxy.on('proxyReq', (proxyReq, req, res) => {
+    console.log(`[HPM] [${req.method}] ${req.url}`); // outputs: [HPM] GET /users
+  });
+},
+
+const config = {
+  target: `http://example.org`,
+  changeOrigin: true,
+  plugins: [simpleRequestLogger],
+};
 ```
 
 ### `logLevel` (string)

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -25,6 +25,8 @@ export class HttpProxyMiddleware {
     this.proxy = httpProxy.createProxyServer({});
     this.logger.info(`[HPM] Proxy created: ${options.pathFilter ?? '/'}  -> ${options.target}`);
 
+    this.registerPlugins(this.proxy, this.proxyOptions);
+
     this.pathRewriter = PathRewriter.createPathRewriter(this.proxyOptions.pathRewrite); // returns undefined when "pathRewrite" is not provided
 
     // attach handler to http-proxy events
@@ -78,6 +80,11 @@ export class HttpProxyMiddleware {
       this.catchUpgradeRequest(server);
     }
   };
+
+  private registerPlugins(proxy: httpProxy, options: Options) {
+    const plugins = options.plugins ?? [];
+    plugins.forEach((plugin) => plugin(proxy, options));
+  }
 
   private catchUpgradeRequest = (server: https.Server) => {
     if (!this.wsInternalSubscribed) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface RequestHandler {
 
 export type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
 
+export type Plugin = (proxy: httpProxy, options: Options) => void;
+
 export interface Options extends httpProxy.ServerOptions {
   /**
    * Narrow down requests to proxy or not.
@@ -32,6 +34,10 @@ export interface Options extends httpProxy.ServerOptions {
     | { [regexp: string]: string }
     | ((path: string, req: Request) => string)
     | ((path: string, req: Request) => Promise<string>);
+  /**
+   * Plugins have access to the internal http-proxy instance to customize behavior.
+   */
+  plugins?: Plugin[];
   router?:
     | { [hostOrPath: string]: httpProxy.ServerOptions['target'] }
     | ((req: Request) => httpProxy.ServerOptions['target'])

--- a/test/e2e/plugins.spec.ts
+++ b/test/e2e/plugins.spec.ts
@@ -1,0 +1,43 @@
+import { createProxyMiddleware, createApp } from './test-kit';
+import * as request from 'supertest';
+import { getLocal, Mockttp } from 'mockttp';
+import type { Options, Plugin } from '../../src/types';
+
+describe('E2E Plugins', () => {
+  let mockTargetServer: Mockttp;
+
+  beforeEach(async () => {
+    mockTargetServer = getLocal();
+    await mockTargetServer.start();
+  });
+
+  afterEach(async () => {
+    await mockTargetServer.stop();
+  });
+
+  it('should register a plugin and access the http-proxy object', async () => {
+    let proxyReqUrl: string;
+    let responseStatusCode: number;
+
+    mockTargetServer.forGet('/users/1').thenReply(200, '{"userName":"John"}');
+
+    const simplePlugin: Plugin = (proxy) => {
+      proxy.on('proxyReq', (proxyReq, req, res, options) => (proxyReqUrl = req.url));
+      proxy.on('proxyRes', (proxyRes, req, res) => (responseStatusCode = proxyRes.statusCode));
+    };
+
+    const config: Options = {
+      target: `http://localhost:${mockTargetServer.port}`,
+      plugins: [simplePlugin], // register a plugin
+    };
+    const proxyMiddleware = createProxyMiddleware(config);
+    const app = createApp(proxyMiddleware);
+    const agent = request(app);
+
+    const response = await agent.get('/users/1').expect(200);
+
+    expect(proxyReqUrl).toBe('/users/1');
+    expect(response.text).toBe('{"userName":"John"}');
+    expect(responseStatusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Write plugins to extend and share proxy functionality, while keeping the core functionality small and clean.
- Exposes internal http-proxy instance; ie. to subscribe to its events directly.

## Motivation and Context

- https://github.com/chimurai/http-proxy-middleware/pull/190
- https://github.com/chimurai/http-proxy-middleware/pull/687

Allow plugins to be created for functionality like:
- https://github.com/chimurai/http-proxy-middleware/discussions/538
- https://github.com/chimurai/http-proxy-middleware/issues/477
- https://github.com/chimurai/http-proxy-middleware/issues/237



## How has this been tested?

- unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
