### PR TITLE
feat(ejectPlugins): skip registering default plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ _All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#option
   - [`pathRewrite` (object/function)](#pathrewrite-objectfunction)
   - [`router` (object/function)](#router-objectfunction)
   - [`plugins` (Array)](#plugins-array)
+  - [`ejectPlugins` (boolean) default: `false`](#ejectplugins-boolean-default-false)
   - [`logger` (Object)](#logger-object)
 - [`http-proxy` events](#http-proxy-events)
 - [`http-proxy` options](#http-proxy-options)
@@ -284,6 +285,30 @@ const config = {
   changeOrigin: true,
   plugins: [simpleRequestLogger],
 };
+```
+
+### `ejectPlugins` (boolean) default: `false`
+
+If you're not satisfied with the pre-configured plugins, you can eject them by configuring `ejectPlugins: true`.
+
+NOTE: register your own error handlers to prevent server from crashing.
+
+```js
+// eject default plugins and manually add them back
+
+const {
+  debugProxyErrorsPlugin, // subscribe to proxy errors to prevent server from crashing
+  loggerPlugin, // log proxy events to a logger (ie. console)
+  errorResponsePlugin, // return 5xx response on proxy error
+  proxyEventsPlugin, // implements the "on:" option
+} = require('http-proxy-middleware/plugins/default');
+
+createProxyMiddleware({
+  target: `http://example.org`,
+  changeOrigin: true,
+  ejectPlugins: true,
+  plugins: [debugProxyErrorsPlugin, loggerPlugin, errorResponsePlugin, proxyEventsPlugin],
+});
 ```
 
 ### `logger` (Object)

--- a/src/get-plugins.ts
+++ b/src/get-plugins.ts
@@ -1,0 +1,15 @@
+import type { Options, Plugin } from './types';
+import {
+  debugProxyErrorsPlugin,
+  loggerPlugin,
+  errorResponsePlugin,
+  proxyEventsPlugin,
+} from './plugins/default';
+
+export function getPlugins(options: Options): Plugin[] {
+  const defaultPlugins: Plugin[] = !!options.ejectPlugins
+    ? [] // no default plugins when ejecting
+    : [debugProxyErrorsPlugin, proxyEventsPlugin, loggerPlugin, errorResponsePlugin];
+  const userPlugins: Plugin[] = options.plugins ?? [];
+  return [...defaultPlugins, ...userPlugins];
+}

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -2,16 +2,11 @@ import type * as https from 'https';
 import type { Request, RequestHandler, Options, Filter, Logger } from './types';
 import * as httpProxy from 'http-proxy';
 import { verifyConfig } from './configuration';
+import { getPlugins } from './get-plugins';
 import { matchPathFilter } from './path-filter';
 import { getLogger } from './logger';
 import * as PathRewriter from './path-rewriter';
 import * as Router from './router';
-import {
-  debugProxyErrorsPlugin,
-  loggerPlugin,
-  errorResponsePlugin,
-  proxyEventsPlugin,
-} from './plugins/default';
 
 export class HttpProxyMiddleware {
   private logger: Logger;
@@ -81,14 +76,8 @@ export class HttpProxyMiddleware {
   };
 
   private registerPlugins(proxy: httpProxy, options: Options) {
-    const defaultPlugins = [
-      debugProxyErrorsPlugin,
-      proxyEventsPlugin,
-      loggerPlugin,
-      errorResponsePlugin,
-    ];
-    const plugins = options.plugins ?? [];
-    [...defaultPlugins, ...plugins].forEach((plugin) => plugin(proxy, options));
+    const plugins = getPlugins(options);
+    plugins.forEach((plugin) => plugin(proxy, options));
   }
 
   private catchUpgradeRequest = (server: https.Server) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,13 @@ export interface Options extends httpProxy.ServerOptions {
    */
   plugins?: Plugin[];
   /**
+   * Eject pre-configured plugins.
+   * NOTE: register your own error handlers to prevent server from crashing.
+   *
+   * @since v3.0.0
+   */
+  ejectPlugins?: boolean;
+  /**
    * Listen to http-proxy events
    * @see {@link OnProxyEvent} for available events
    * @example

--- a/test/unit/get-plugins.spec.ts
+++ b/test/unit/get-plugins.spec.ts
@@ -1,0 +1,88 @@
+import { Plugin } from '../../src/types';
+import { getPlugins } from '../../src/get-plugins';
+import {
+  debugProxyErrorsPlugin,
+  loggerPlugin,
+  errorResponsePlugin,
+  proxyEventsPlugin,
+} from '../../src/plugins/default';
+
+describe('getPlugins', () => {
+  let plugins: Plugin[];
+
+  it('should return default plugins when no user plugins are provided', () => {
+    plugins = getPlugins({});
+
+    expect(plugins).toHaveLength(4);
+    expect(plugins.map((plugin) => plugin.name)).toMatchInlineSnapshot(`
+      Array [
+        "debugProxyErrorsPlugin",
+        "proxyEventsPlugin",
+        "loggerPlugin",
+        "errorResponsePlugin",
+      ]
+    `);
+  });
+
+  it('should return no plugins when ejectPlugins is configured in option', () => {
+    plugins = getPlugins({
+      ejectPlugins: true,
+    });
+
+    expect(plugins).toHaveLength(0);
+  });
+
+  it('should return user plugins with default plugins when user plugins are provided', () => {
+    const myPlugin: Plugin = () => {
+      /* noop */
+    };
+    plugins = getPlugins({
+      plugins: [myPlugin],
+    });
+
+    expect(plugins).toHaveLength(5);
+    expect(plugins.map((plugin) => plugin.name)).toMatchInlineSnapshot(`
+      Array [
+        "debugProxyErrorsPlugin",
+        "proxyEventsPlugin",
+        "loggerPlugin",
+        "errorResponsePlugin",
+        "myPlugin",
+      ]
+    `);
+  });
+
+  it('should only return user plugins when user plugins are provided with ejectPlugins option', () => {
+    const myPlugin: Plugin = () => {
+      /* noop */
+    };
+    plugins = getPlugins({
+      ejectPlugins: true,
+      plugins: [myPlugin],
+    });
+
+    expect(plugins).toHaveLength(1);
+    expect(plugins.map((plugin) => plugin.name)).toMatchInlineSnapshot(`
+      Array [
+        "myPlugin",
+      ]
+    `);
+  });
+
+  it('should return manually added default plugins in different order after using ejectPlugins', () => {
+    plugins = getPlugins({
+      ejectPlugins: true,
+      plugins: [debugProxyErrorsPlugin, errorResponsePlugin, loggerPlugin, proxyEventsPlugin], // alphabetical order
+    });
+
+    expect(plugins).toHaveLength(4);
+    expect(plugins.map((plugin) => plugin.name)).toMatchInlineSnapshot(`
+      Array [
+        "debugProxyErrorsPlugin",
+        "errorResponsePlugin",
+        "loggerPlugin",
+        "proxyEventsPlugin",
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add `ejectPlugins` option

## Motivation and Context

http-proxy-middleware is configured with some default plugins for common use cases.
Allow the proxy behaviour to be fully customised with `ejectPlugins: true`.

## How has this been tested?

- docs
- unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
