### PR TITLE
feat(legacyCreateProxyMiddleware): show migration tips

### DIFF
--- a/test/legacy/http-proxy-middleware.spec.ts
+++ b/test/legacy/http-proxy-middleware.spec.ts
@@ -100,5 +100,6 @@ describe('legacyCreateProxyMiddleware()', () => {
     expect(response.text).toBe('my legacy error');
 
     expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display upgrade tips when `legacyCreateProxyMiddleware()` is used with legacy features.

![image](https://user-images.githubusercontent.com/655241/164068802-a4615422-b884-4851-8b72-c7bfacf4d8a0.png)


## Motivation and Context

DX;
Allow users to use `legacyCreateProxyMiddleware()` as intermediate upgrade, before fully migrating to v3

## How has this been tested?

- unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
