### PR TITLE
fix(error handler): add default handler to econnreset

### DIFF
--- a/src/_handlers.ts
+++ b/src/_handlers.ts
@@ -11,6 +11,10 @@ export function init(proxy: httpProxy, option: Options): void {
     proxy.on(eventName, handlers[eventName]);
   }
 
+  proxy.on('econnreset', (err, req, res, target) => {
+    logger.error(`[HPM] ECONNRESET: %s`, err);
+  });
+
   logger.debug('[HPM] Subscribed to http-proxy events:', Object.keys(handlers));
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add default handler to http-proxy `econnreset` event.

This event is not documented in official documentation:
https://github.com/http-party/node-http-proxy#listening-for-proxy-events

It is typed in:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e626d3221693ea35ae4298bc8192ac4abebd225f/types/http-proxy/index.d.ts#L109

Event is emitted:
https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/lib/http-proxy/passes/web-incoming.js#L158

## Motivation and Context

Lack of this handler potentially causes server to crash (unconfirmed, difficult to replicate)

- https://github.com/webpack/webpack-dev-server/issues/1642

## How has this been tested?

hotfix 🤞

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
