### PR TITLE
fix(proxyReqWs): catch socket errors

### DIFF
--- a/src/_handlers.ts
+++ b/src/_handlers.ts
@@ -11,8 +11,16 @@ export function init(proxy: httpProxy, option: Options): void {
     proxy.on(eventName, handlers[eventName]);
   }
 
-  proxy.on('econnreset', (err, req, res, target) => {
-    logger.error(`[HPM] ECONNRESET: %s`, err);
+  // https://github.com/webpack/webpack-dev-server/issues/1642
+  proxy.on('econnreset', (error, req, res, target) => {
+    logger.error(`[HPM] ECONNRESET: %O`, error);
+  });
+
+  // https://github.com/webpack/webpack-dev-server/issues/1642#issuecomment-1104325120
+  proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
+    socket.on('error', (error) => {
+      logger.error(`[HPM] WebSocket error: %O`, error);
+    });
   });
 
   logger.debug('[HPM] Subscribed to http-proxy events:', Object.keys(handlers));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add socket error handler for `proxyReqWs`

## Motivation and Context

hopefully fixes: https://github.com/webpack/webpack-dev-server/issues/1642
related: https://github.com/chimurai/http-proxy-middleware/pull/759

## How has this been tested?

Relying on feedback from: https://github.com/webpack/webpack-dev-server/issues/1642#issuecomment-1104325120

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
