### PR TITLE
fix(logger-plugin): fix next.js url logging (baseUrl not supported)

### DIFF
--- a/src/plugins/default/logger-plugin.ts
+++ b/src/plugins/default/logger-plugin.ts
@@ -24,7 +24,8 @@ export const loggerPlugin: Plugin = (proxyServer, options) => {
    */
   proxyServer.on('proxyRes', (proxyRes: any, req: any, res) => {
     // BrowserSync uses req.originalUrl
-    const originalUrl = req.originalUrl ?? `${req.baseUrl}${req.path}`;
+    // Next.js doesn't have req.baseUrl
+    const originalUrl = req.originalUrl ?? `${req.baseUrl || ''}${req.url}`;
     const exchange = `[HPM] ${req.method} ${originalUrl} -> ${proxyRes.req.protocol}//${proxyRes.req.host}${proxyRes.req.path} [${proxyRes.statusCode}]`;
     logger.info(exchange);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fixes

```
[HPM] GET undefinedundefined -> http://jsonplaceholder.typicode.com/users [304]
```

## Motivation and Context

Next.js doesn't seem to expose the baseUrl (/api) ...

## How has this been tested?

Manual

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
