### PR TITLE
fix: keep cookie-domain in set-cookie header after proxy

### DIFF
--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -95,15 +95,7 @@ function copyHeaders(originalResponse, response) {
     keys = keys.filter((key) => !['content-encoding', 'transfer-encoding'].includes(key));
 
     keys.forEach((key) => {
-      let value = originalResponse.headers[key];
-
-      if (key === 'set-cookie') {
-        // remove cookie domain
-        value = Array.isArray(value) ? value : [value];
-        value = value.map((x) => x.replace(/Domain=[^;]+?/i, ''));
-      }
-
-      response.setHeader(key, value);
+      response.setHeader(key, originalResponse.headers[key]);
     });
   } else {
     response.headers = originalResponse.headers;

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -65,6 +65,16 @@ describe('responseInterceptor()', () => {
         .expect('set-cookie', /.*cookie=monster.*/)
         .expect(302);
     });
+
+    it('should proxy and return original domain of set-cookie headers', async () => {
+      return agent
+        .get(
+          `/response-headers?set-cookie=${encodeURIComponent(
+            'JSESSIONID=monster;Domain=httpbin.com;Path=/;SameSite=Lax'
+          )}`
+        )
+        .expect('set-cookie', /.*Domain=httpbin.com.*/);
+    });
   });
 
   describe('intercept compressed responses', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before this commit, Domain property of `set-cookie` header was trying to remove. But the regex is incorrect with lazy mode, cause if we had a `JSESSIONID=monster;Domain=httpbin.com;`, after proxy we got `JSESSIONID=monster;ttpbin.com;`, only `Domain=` and first character of domain value was removed. 

But in my opinion, we should not remove the cookie domain. If the domain is matched with client side, the domain should set as server expected, otherwise the cookie should drop by browser or client by default. Or if some cases need to change the domain of cookie, use response interceptor is better. 

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

I've created e2e test for this case, and all unit tests passed. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
