### PR TITLE
fix(responseInterceptor): remove disallowed headers when response headers contains trailer

### DIFF
--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -13,6 +13,19 @@ type Interceptor<TReq = http.IncomingMessage, TRes = http.ServerResponse> = (
   res: TRes,
 ) => Promise<Buffer | string>;
 
+const TrailerDisallowHeaders: string[] = [
+  'content-length',
+  'host',
+  'content-type',
+  'authorization',
+  'cache-control',
+  'max-forwards',
+  'te',
+  'set-cookie',
+  'content-encoding',
+  'content-range',
+];
+
 /**
  * Intercept responses from upstream.
  * Automatically decompress (deflate, gzip, brotli).
@@ -49,8 +62,14 @@ export function responseInterceptor<
 
       // set correct content-length (with double byte character support)
       debug('set content-length: %s', Buffer.byteLength(interceptedBuffer, 'utf8'));
-      res.setHeader('content-length', Buffer.byteLength(interceptedBuffer, 'utf8'));
-
+      // some headers are disallowed when response headers contains trailer
+      if (proxyRes.headers.trailer === undefined) {
+        res.setHeader('content-length', Buffer.byteLength(interceptedBuffer, 'utf8'));
+      } else {
+        TrailerDisallowHeaders.forEach((value) => {
+          res.removeHeader(value);
+        });
+      }
       debug('write intercepted response');
       res.write(interceptedBuffer);
       res.end();

--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -13,6 +13,10 @@ type Interceptor<TReq = http.IncomingMessage, TRes = http.ServerResponse> = (
   res: TRes,
 ) => Promise<Buffer | string>;
 
+/**
+ * Disallow headers when response contains trailer
+ * source: https://developer.mozilla.org/docs/Web/HTTP/Headers/Trailer
+ */
 const TrailerDisallowHeaders: string[] = [
   'content-length',
   'host',

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -31,6 +31,15 @@ describe('responseInterceptor()', () => {
         'content-type': 'image/png',
       });
 
+      await targetServer
+        .forGet('/response-headers')
+        .withExactQuery('?Trailer=X-Stream-Error&Host=localhost')
+        .thenReply(200, '', {
+          'transfer-encoding': 'chunked',
+          trailer: 'X-Stream-Error',
+          host: 'localhost',
+        });
+
       agent = request(
         createApp(
           createProxyMiddleware({
@@ -66,7 +75,7 @@ describe('responseInterceptor()', () => {
       expect(response.body.favorite).toEqual('叉燒包');
     });
 
-    it('should not contains disallow headers to trailer in response headers http://httpbin.org/response-headers', async () => {
+    it('should not contains disallow headers to trailer in response headers', async () => {
       const response = await agent
         .get('/response-headers?Trailer=X-Stream-Error&Host=localhost')
         .expect(200);

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -65,6 +65,13 @@ describe('responseInterceptor()', () => {
       const response = await agent.get(`/json`).expect(200);
       expect(response.body.favorite).toEqual('叉燒包');
     });
+
+    it('should not contains disallow headers to trailer in response headers http://httpbin.org/response-headers', async () => {
+      const response = await agent
+        .get('/response-headers?Trailer=X-Stream-Error&Host=localhost')
+        .expect(200);
+      expect(response.header['host']).toBeUndefined();
+    });
   });
 
   describe('intercept responses with original headers', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Process will exit  when proxy response header both contains `trailer` and disallow headers eg.`content-length`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

I've created e2e test for this case, and all unit tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<a href="https://gitpod.io/#https://github.com/chimurai/http-proxy-middleware/pull/830"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response header handling when HTTP Trailer headers are present: incompatible headers are now excluded and content-length is only set when no trailers are sent, preventing incorrect/ambiguous response headers.
* **Tests**
  * Added an end-to-end test to verify proxied responses with trailers do not include disallowed headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->