### PR TITLE
fix(utils): fixRequestBody support `multipart/form-data`

### DIFF
--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -20,11 +20,27 @@ export function fixRequestBody(proxyReq: http.ClientRequest, req: Request): void
     proxyReq.write(bodyData);
   };
 
+  const handlerFormDataBodyData = (
+    contentType: string,
+    data: any
+  ) => {
+    const boundary = contentType.replace(/^.*boundary=(.*)$/, "$1");
+    let str = "";
+    for (const [key, value] of Object.entries(data)) {
+      str += `--${boundary}\r\nContent-Disposition: form-data; name="${key}"\r\n\r\n${value}\r\n`;
+    }
+    return str;
+  };
+
   if (contentType && contentType.includes('application/json')) {
     writeBody(JSON.stringify(requestBody));
   }
 
   if (contentType && contentType.includes('application/x-www-form-urlencoded')) {
     writeBody(querystring.stringify(requestBody));
+  }
+
+  if (contentType && contentType.includes("multipart/form-data")) {
+    writeBody(handlerFormDataBodyData(contentType, req.body));
   }
 }


### PR DESCRIPTION
The fixRequestBody method provided now does not support the handling of the type for which `Content- type` is `multipart/form- data`. This pr has modified the method to support this type.

<a href="https://gitpod.io/#https://github.com/chimurai/http-proxy-middleware/pull/833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

