### PR TITLE
The Nodejitsu GitHub org became http-party

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Node.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/expressjs/express), [next.js](https://github.com/vercel/next.js) and [many more](#compatible-servers).
 
-Powered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)
+Powered by the popular Nodejitsu [`http-proxy`](https://github.com/http-party/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)
 
 ## ⚠️ Note <!-- omit in toc -->
 


### PR DESCRIPTION
Also, they [haven't been maintaining the module since 2020](https://github.com/http-party/node-http-proxy/issues/1588), and it has 470+ open issues.

<a href="https://gitpod.io/#https://github.com/chimurai/http-proxy-middleware/pull/836"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

