### PR TITLE
Updated misleading documentation for 3.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/chimurai/http-proxy-middleware/CI/master?style=flat-square&logo=github-actions&logoColor=white)](https://github.com/chimurai/http-proxy-middleware/actions?query=branch%3Amaster)
 [![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square&logo=coveralls)](https://coveralls.io/r/chimurai/http-proxy-middleware)
 ![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/chimurai/http-proxy-middleware?logo=snyk&style=flat-square)
-[![npm](https://img.shields.io/npm/v/http-proxy-middleware?color=%23CC3534&style=flat-square&logo=npm)](https://www.npmjs.com/package/http-proxy-middleware)
+[![npm](https://img.shields.io/npm/v/http-proxy-middleware?color=%23CC3534&style=flat-square&logo=npm&label=stable)](https://www.npmjs.com/package/http-proxy-middleware)
+[![npm](https://img.shields.io/static/v1?color=%23CC3534&style=flat-square&logo=npm&label=latest&message=3.0.0-beta.0)](https://www.npmjs.com/package/http-proxy-middleware/v/3.0.0-beta.0)
 
 Node.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/expressjs/express), [next.js](https://github.com/vercel/next.js) and [many more](#compatible-servers).
 
@@ -11,7 +12,7 @@ Powered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/nod
 
 ## ⚠️ Note <!-- omit in toc -->
 
-This page is showing documentation for version v3.x.x ([release notes](https://github.com/chimurai/http-proxy-middleware/releases))
+This page is showing documentation for version **v3.0.0-beta.0** ([release notes](https://github.com/chimurai/http-proxy-middleware/releases))
 
 See [MIGRATION.md](https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md) for details on how to migrate from v2.x.x to v3.x.x
 
@@ -107,7 +108,7 @@ _All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#option
 ## Install
 
 ```shell
-npm install --save-dev http-proxy-middleware
+npm install --save-dev http-proxy-middleware@3.0.0-beta.0
 ```
 
 ## Basic usage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates misleading documentation about the latest version (3.0.0-beta.0):

- Added new npm badge clarifying the difference between default npm version (stable v2) and beta version (v2) [![npm](https://img.shields.io/npm/v/http-proxy-middleware?color=%23CC3534&style=flat-square&logo=npm&label=stable)](https://www.npmjs.com/package/http-proxy-middleware)
[![npm](https://img.shields.io/static/v1?color=%23CC3534&style=flat-square&logo=npm&label=latest&message=3.0.0-beta.0)](https://www.npmjs.com/package/http-proxy-middleware/v/3.0.0-beta.0)
- Updated "Install" section to include the full version of 3.0.0-beta.0
  <img width="348" alt="image" src="https://user-images.githubusercontent.com/2074685/201656543-db368686-67db-4909-b5d4-46bbc91fb4e4.png">


<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default version installed from npm is still the v2 because v3 is suffixed with a prerelease version ("beta").

This causes a misleading installation when developers just run `npm install http-proxy-middleware`.

![image](https://user-images.githubusercontent.com/2074685/201655964-ca1319e6-5648-4515-86d9-b4d36792fde9.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Documentation fix (non-breaking change which clarifies documentation)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


<a href="https://gitpod.io/#https://github.com/chimurai/http-proxy-middleware/pull/849"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

