### PR TITLE
http-proxy-middleware.ts Return promise to wait end of connection

### DIFF
--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -43,6 +43,7 @@ export class HttpProxyMiddleware {
         const activeProxyOptions = await this.prepareProxyRequest(req);
         debug(`proxy request to target: %O`, activeProxyOptions.target);
         this.proxy.web(req, res, activeProxyOptions);
+        return new Promise(r=>this.proxy.web.on('end',()=>r()));
       } catch (err) {
         next && next(err);
       }


### PR DESCRIPTION
It allows koajs handle http-proxy-middleware, awaiting end of transaction from proxy, if you don't handle it, response will be emitted before end of proxy request.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow handle propperly end of remote connection before emit response to client.

## Motivation and Context

Koajs compability

## How has this been tested?

const app = new koa();
app.use(async ({req,res},next)=>{
    const Proxy = createProxyMiddleware(options);
    await Proxy(req,res,next);
}});

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
