### PR TITLE
Update markdown example code sections to fix syntax highlighting

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -65,8 +65,8 @@ It was common to rewrite the `basePath` with the `pathRewrite` option:
 ```js
 // before
 app.use('/user', proxy({
-  target: 'http://www.example.org'
-  pathRewrite: { '^/user': '/secret' }
+  target: 'http://www.example.org',
+  pathRewrite: { '^/user': '/secret' },
 }));
 
 // after
@@ -78,8 +78,8 @@ When proxy is mounted at the root, `pathRewrite` should still work as in v2.
 ```js
 // not affected
 app.use(proxy({
-  target: 'http://www.example.org'
-  pathRewrite: { '^/user': '/secret' }
+  target: 'http://www.example.org',
+  pathRewrite: { '^/user': '/secret' },
 }));
 ```
 


### PR DESCRIPTION
## Description

Added some commas to fix the syntax highlighting in the markdown sections

## Motivation and Context

I was reading the docs and noticed it. So I figured I could clean up a little while I'm here.

## How has this been tested?

Documentation change, no production code affected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Change

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
