### PR TITLE
ci: drop node v14 and v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Node v16 EOL: 2023-09-11

https://nodejs.org/en/blog/announcements/nodejs16-eol/