### PR TITLE
test(types): contextual types

### DIFF
--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -193,56 +193,56 @@ describe('http-proxy-middleware TypeScript Types', () => {
       expect(app).toBeDefined();
     });
 
-    // FIXME: contextual types should work with express path middleware
-    // it('should get contextual types from express server', () => {
-    //   const app = express();
-    //   app.use(
-    //     '/',
-    //     middleware({
-    //       router: (req) => req.params,
-    //       pathFilter: (pathname, req) => !!req.params,
-    //       on: {
-    //         error(error, req, res, target) {
-    //           req.params;
+    it('should get contextual types from express server', () => {
+      const app = express();
+      app.use(
+        '/',
+        // FIXME: contextual types should work with express path middleware (without providing explicit types)
+        middleware<express.Request, express.Response>({
+          router: (req) => req.params,
+          pathFilter: (pathname, req) => !!req.params,
+          on: {
+            error(error, req, res, target) {
+              req.params;
 
-    //           // https://www.typescriptlang.org/docs/handbook/2/narrowing.html
-    //           if (res instanceof http.ServerResponse) {
-    //             res.status(200).send('OK');
-    //           }
-    //         },
-    //         proxyReq(proxyReq, req, res, options) {
-    //           req.params;
-    //           res.status(200).send('OK');
-    //         },
-    //         proxyReqWs(proxyReq, req, socket, options, head) {
-    //           req.params;
-    //         },
-    //         proxyRes(proxyRes, req, res) {
-    //           req.params;
-    //           res.status(200).send('OK');
-    //         },
-    //         close(proxyRes, proxySocket, proxyHead) {
-    //           proxyRes.params;
-    //         },
-    //         start(req, res, target) {
-    //           req.params;
-    //           res.status(200).send('OK');
-    //         },
-    //         end(req, res, proxyRes) {
-    //           req.params;
-    //           res.status(200).send('OK');
-    //           proxyRes.params;
-    //         },
-    //         econnreset(error, req, res, target) {
-    //           req.params;
-    //           res.status(200).send('OK');
-    //         },
-    //       },
-    //     })
-    //   );
+              // https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+              if (res instanceof http.ServerResponse) {
+                res.status(200).send('OK');
+              }
+            },
+            proxyReq(proxyReq, req, res, options) {
+              req.params;
+              res.status(200).send('OK');
+            },
+            proxyReqWs(proxyReq, req, socket, options, head) {
+              req.params;
+            },
+            proxyRes(proxyRes, req, res) {
+              req.params;
+              res.status(200).send('OK');
+            },
+            close(proxyRes, proxySocket, proxyHead) {
+              proxyRes.params;
+            },
+            start(req, res, target) {
+              req.params;
+              res.status(200).send('OK');
+            },
+            end(req, res, proxyRes) {
+              req.params;
+              res.status(200).send('OK');
+              proxyRes.params;
+            },
+            econnreset(error, req, res, target) {
+              req.params;
+              res.status(200).send('OK');
+            },
+          },
+        }),
+      );
 
-    //   expect(app).toBeDefined();
-    // });
+      expect(app).toBeDefined();
+    });
 
     it('should work with explicit generic custom req & res types', () => {
       interface MyRequest extends http.IncomingMessage {


### PR DESCRIPTION
Enable test and include temporary workaround by providing explicit types:

```js
// FIXME: contextual types should work with express path middleware (without providing explicit types)
middleware<express.Request, express.Response>
```