### PR TITLE
docs(responseInterceptor): fix header manipulation example

### DIFF
--- a/recipes/response-interceptor.md
+++ b/recipes/response-interceptor.md
@@ -158,6 +158,7 @@ const proxy = createProxyMiddleware({
     proxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
       res.removeHeader('content-security-policy'); // Remove the Content Security Policy header
       res.setHeader('HPM-Header', 'Intercepted by HPM'); // Set a new header and value
+      return responseBuffer;
     }),
   },
 });


### PR DESCRIPTION
## Description

`responseInterceptor` expects its function argument to return a value that can be passed to `Buffer.from`.

## Motivation and Context

The documentation is misleading.

## How has this been tested?

Confirmed locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
