### PR TITLE
fix(proxyReqWs): catch socket errors on 0.19.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,14 @@ function HttpProxyMiddleware(context, opts) {
 
   // log errors for debug purpose
   proxy.on('error', logError)
+  proxy.on('econnreset', (err, req, res, target) => {
+    logger.error(`[HPM] ECONNRESET: %s`, err.message);
+  });
+  proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
+      socket.on('error', (error) => {
+          logger.error(`[HPM] WebSocket error: %s`, error.message);
+      });
+  });
 
   // https://github.com/chimurai/http-proxy-middleware/issues/19
   // expose function to upgrade externally


### PR DESCRIPTION
This PR fixes [issue #1642](https://github.com/webpack/webpack-dev-server/issues/1642) on the 0.19.x branch. 

## Description

The PR copies proposed changes form this [comment](https://github.com/webpack/webpack-dev-server/issues/1642#issuecomment-1104325120)

## Motivation and Context

The issue has already been fixed and closed on newer versions. Unfortunately we are using an older version of angular and one of the core angular libraries use the 0.19.1 version of this package. We've created a private fork with this fix, but figured, someone could use this as well. 

## How has this been tested?

We've created a fork for a private npm feed. It works well for us. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
 
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.

## PS
This is my first ever contribution to a public repo. I've tried to follow every policy, as best as I could. Sorry, if I missed something.