### PR TITLE
fix(fix-request-body): support '+json' content-type suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - ci(package): npm package provenance
 - fix(logger-plugin): log target port when router option is used
 - refactor: fix circular dependencies
+- fix(fix-request-body): support '+json' content-type suffix
 
 ## [v3.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v3.0.0)
 

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -23,7 +23,7 @@ export function fixRequestBody<TReq = http.IncomingMessage>(
     proxyReq.write(bodyData);
   };
 
-  if (contentType && contentType.includes('application/json')) {
+  if (contentType && (contentType.includes('application/json') || contentType.endsWith('+json'))) {
     writeBody(JSON.stringify(requestBody));
   }
 

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -23,7 +23,7 @@ export function fixRequestBody<TReq = http.IncomingMessage>(
     proxyReq.write(bodyData);
   };
 
-  if (contentType && (contentType.includes('application/json') || contentType.endsWith('+json'))) {
+  if (contentType && (contentType.includes('application/json') || contentType.includes('+json'))) {
     writeBody(JSON.stringify(requestBody));
   }
 

--- a/test/unit/fix-request-body.spec.ts
+++ b/test/unit/fix-request-body.spec.ts
@@ -57,6 +57,20 @@ describe('fixRequestBody', () => {
     expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
   });
 
+  it('should write when body is not empty and Content-Type ends with +json', () => {
+    const proxyRequest = fakeProxyRequest();
+    proxyRequest.setHeader('content-type', 'application/merge-patch+json; charset=utf-8');
+
+    jest.spyOn(proxyRequest, 'setHeader');
+    jest.spyOn(proxyRequest, 'write');
+
+    fixRequestBody(proxyRequest, createRequestWithBody({ someField: 'some value' }));
+
+    const expectedBody = JSON.stringify({ someField: 'some value' });
+    expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
+    expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
+  });
+
   it('should write when body is not empty and Content-Type is application/x-www-form-urlencoded', () => {
     const proxyRequest = fakeProxyRequest();
     proxyRequest.setHeader('content-type', 'application/x-www-form-urlencoded');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Enhance `fixRequestBody` method to fix `Content-Type` includes `+json`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now, if our Media Type includes `+json` but does not includes `application/json`, the `fixRequestBody` method will not work. For example, the Media Type is `application/merge-patch+json`.

According to [RFC 6838](https://datatracker.ietf.org/doc/html/rfc6838#section-4.2.8), the `+` suffix indicates a structured type. Therefore, for the Media Type includes `+json`, we can directly serialize it to JSON.

This PR fixes the issue where the `fixRequestBody` method does not work for Media Types includes `+json`, such as `application/merge-patch+json`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unit Test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
