### PR TITLE
chore(package.json): add type: commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "http-proxy-middleware",
+  "type": "commonjs",
   "version": "3.0.1-beta.1",
   "description": "The one-liner node.js proxy middleware for connect, express, next.js and more",
   "main": "dist/index.js",


### PR DESCRIPTION
fix package.json warnings from: https://publint.dev/http-proxy-middleware

- add package.json `type: commonjs` (https://publint.dev/rules#use_type)
