### PR TITLE
Improve matchPathFilter to handle mixed arrays of string and glob paths

### DIFF
--- a/src/path-filter.ts
+++ b/src/path-filter.ts
@@ -22,13 +22,22 @@ export function matchPathFilter<TReq = http.IncomingMessage>(
 
   // multi path
   if (Array.isArray(pathFilter)) {
-    if (pathFilter.every(isStringPath)) {
+    const stringPaths = pathFilter.filter(isStringPath);
+    const globPaths = pathFilter.filter(isGlobPath);
+
+    // Handle mixed arrays
+    if (stringPaths.length && globPaths.length) {
+      return (
+        matchMultiPath(stringPaths, uri) ||
+        matchMultiGlobPath(globPaths, uri)
+      );
+    }
+    if (stringPaths.length) {
       return matchMultiPath(pathFilter, uri);
     }
-    if (pathFilter.every(isGlobPath)) {
-      return matchMultiGlobPath(pathFilter as string[], uri);
+    if (globPaths.length) {
+      return matchMultiGlobPath(pathFilter, uri);
     }
-
     throw new Error(ERRORS.ERR_CONTEXT_MATCHER_INVALID_ARRAY);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The matchPathFilter function has been enhanced to handle mixed arrays of string and glob paths. This allows for more flexible URI matching, accommodating cases where both types of paths are specified in the same array.

## Motivation and Context

This change is necessary to improve the functionality of the matchPathFilter function. Previously, it did not support arrays containing both string and glob paths, which could lead to unexpected behavior or failed matches. This enhancement addresses that limitation, allowing developers to utilize mixed path types seamlessly.

Error: [HPM] Invalid pathFilter. Expecting something like: ["/api", "/ajax"] or ["/api/**", "!**.html"]

## How has this been tested?

The changes were tested with various scenarios, including:

- Single string path matching.
- Single glob path matching.
- Mixed arrays containing both string and glob paths.
- Edge cases with empty arrays or arrays with unsupported types.

Testing was performed in a local development environment and validated against existing unit tests for regression.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
