### PR TITLE
ci(github-actions): pipeline improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,36 @@ name: CI
 on: ['push', 'pull_request']
 
 jobs:
+  dependencies:
+    name: Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: yarn install
+        if: steps.yarn-cache.outputs.cache-hit != 'true' # Over here!
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+        env:
+          CI: true
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: [dependencies]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +62,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [dependencies]
 
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +92,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [dependencies]
 
     strategy:
       matrix:
@@ -97,6 +126,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    needs: [dependencies]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
add `dependencies` build step to install and cache dependencies 

Preventing this error when multiple jobs try to update/create the cache:

> Failed to save: Unable to reserve cache with key Linux-yarn-7f6dd4a8bff79fc4bd6feeff99e0401a54af1c318a2b7eebccb7590a85811e2e, another job may be creating this cache.
