### PR TITLE
build(patch-package): run patch-package in 'development' only

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   ],
   "scripts": {
     "clean": "rm -rf dist coverage tsconfig.tsbuildinfo .eslintcache",
-    "postinstall": "patch-package",
     "install:all": "yarn && (cd examples && yarn)",
     "lint": "yarn prettier && yarn eslint",
     "lint:fix": "yarn prettier:fix && yarn eslint:fix",
@@ -21,7 +20,7 @@
     "build": "tsc --build",
     "test": "jest",
     "coverage": "jest --coverage",
-    "prepare": "husky",
+    "prepare": "husky && patch-package",
     "prepack": "yarn clean && yarn test && yarn build",
     "spellcheck": "npx --yes cspell --show-context --show-suggestions '**/*.*'"
   },


### PR DESCRIPTION
fix error during installation:

<img width="672" alt="image" src="https://github.com/user-attachments/assets/1cceb790-6084-4eb2-9764-d9a31998467c" />

introduced by: https://github.com/chimurai/http-proxy-middleware/pull/1084

