### PR TITLE
fix(fixRequestBody): prevent multiple .write() calls

### DIFF
--- a/test/unit/fix-request-body.spec.ts
+++ b/test/unit/fix-request-body.spec.ts
@@ -154,4 +154,19 @@ describe('fixRequestBody', () => {
     expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
     expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
   });
+
+  it('should parse json and call write() once with incorrect content-type application/x-www-form-urlencoded+json', () => {
+    const proxyRequest = fakeProxyRequest();
+    proxyRequest.setHeader('content-type', 'application/x-www-form-urlencoded+json');
+
+    jest.spyOn(proxyRequest, 'setHeader');
+    jest.spyOn(proxyRequest, 'write');
+
+    fixRequestBody(proxyRequest, createRequestWithBody({ someField: 'some value' }));
+
+    const expectedBody = JSON.stringify({ someField: 'some value' });
+    expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
+    expect(proxyRequest.write).toHaveBeenCalledTimes(1);
+    expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
+  });
 });


### PR DESCRIPTION
Causing this error: `Cannot set headers after they are sent to the client`