### PR TITLE
fix: handle invalid `logger` in `getLogger` during runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/is-glob": "4.0.4",
     "@types/jest": "29.5.14",
     "@types/micromatch": "4.0.9",
-    "@types/node": "22.10.2",
+    "@types/node": "^22.10.2",
     "@types/supertest": "6.0.2",
     "@types/ws": "8.18.0",
     "body-parser": "1.20.3",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,6 +19,29 @@ const noopLogger: Logger = {
   error: () => {},
 };
 
+function isLogger(obj: any): obj is Logger {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    typeof obj.info === 'function' &&
+    typeof obj.warn === 'function' &&
+    typeof obj.error === 'function'
+  );
+}
+
 export function getLogger(options: Options): Logger {
-  return (options.logger as Logger) || noopLogger;
+  const { logger } = options;
+
+  if (logger === undefined) {
+    return noopLogger;
+  }
+
+  if (!isLogger(logger)) {
+    console.warn(
+      '[http-proxy-middleware] Invalid logger provided. Falling back to default noopLogger.'
+    );
+    return noopLogger;
+  }
+
+  return logger;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "incremental": true,
     "declaration": true,
     "strict": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": ["node"],
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR adds runtime validation for the `logger` option passed to `getLogger`. If the logger does not implement the required logging methods, the function now logs a warning and falls back to the `noopLogger`. It can be changed to throw an error, which might lead to a "Breaking change".

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The current implementation of `getLogger` assumes that if a logger is passed, it always matches the expected `Logger` interface unless the `logger` option is `undefined` or its value is `null` where the original code `return (options.logger as Logger) || noopLogger;` returns noopLogger.
- This can lead to subtle bugs or runtime errors if the logger is a number, string, or any other object
Example:
```TypeScript
const logger = getLogger({ logger: 500 });
console.log(logger)     // prints 500
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
