### PR TITLE
fix(fixRequestBody): support text/plain

### DIFF
--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -40,6 +40,8 @@ export function fixRequestBody<TReq extends BodyParserLikeRequest = BodyParserLi
     writeBody(querystring.stringify(requestBody));
   } else if (contentType.includes('multipart/form-data')) {
     writeBody(handlerFormDataBodyData(contentType, requestBody));
+  } else if (contentType.includes('text/plain')) {
+    writeBody(requestBody);
   }
 }
 

--- a/test/unit/fix-request-body.spec.ts
+++ b/test/unit/fix-request-body.spec.ts
@@ -57,6 +57,20 @@ describe('fixRequestBody', () => {
     expect(proxyRequest.write).toHaveBeenCalled();
   });
 
+  it('should write when body is not empty and Content-Type is text/plain', () => {
+    const proxyRequest = fakeProxyRequest();
+    proxyRequest.setHeader('content-type', 'text/plain; charset=utf-8');
+
+    jest.spyOn(proxyRequest, 'setHeader');
+    jest.spyOn(proxyRequest, 'write');
+
+    fixRequestBody(proxyRequest, createRequestWithBody('some string'));
+
+    const expectedBody = 'some string';
+    expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
+    expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
+  });
+
   it('should write when body is not empty and Content-Type is application/json', () => {
     const proxyRequest = fakeProxyRequest();
     proxyRequest.setHeader('content-type', 'application/json; charset=utf-8');


### PR DESCRIPTION
## Description
Adds Content-Type text/plain to bodies that are forwarded w/ fixRequestBody. Crucial since bodyParser handles that content-type.

## Motivation and Context

Discovered this issue when a proxy server that was using bodyParser used fixRequestBody to forward bodies over to an API. The API would receive a request with a non-zero Content-Length but an empty body, so the API would be in deadlock trying to read from a stream that never would never have any data.

fixes [1102](https://github.com/chimurai/http-proxy-middleware/issues/1102)

## How has this been tested?

I added a unit test for this case

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
