### PR TITLE
chore(deps): fix punycode node deprecation warning

### DIFF
--- a/NODE_DEPRECATIONS.md
+++ b/NODE_DEPRECATIONS.md
@@ -1,0 +1,24 @@
+# Node deprecation warnings
+
+Patch npm dependencies with:
+
+- Use `patch-package` (<https://www.npmjs.com/package/patch-package>)
+- Or with `pnpm`
+  - <https://pnpm.io/cli/patch>
+  - vite example: <https://github.com/vitejs/vite/pull/16655>
+
+## `util._extend`
+
+<https://github.com/chimurai/http-proxy-middleware/pull/1084>
+
+```shell
+[DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
+```
+
+## `punycode`
+
+<https://github.com/chimurai/http-proxy-middleware/pull/1109>
+
+```shell
+[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+```

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
     "node_modules/**",
     "coverage/**",
     "dist/**",
+    "patches/**",
     "tsconfig.tsbuildinfo",
     "package.json",
     "yarn.lock",

--- a/patches/tr46+0.0.3.patch
+++ b/patches/tr46+0.0.3.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/tr46/index.js b/node_modules/tr46/index.js
+index 9ce12ca..7c3b5d7 100644
+--- a/node_modules/tr46/index.js
++++ b/node_modules/tr46/index.js
+@@ -1,6 +1,6 @@
+ "use strict";
+ 
+-var punycode = require("punycode");
++var punycode = require("punycode/");
+ var mappingTable = require("./lib/mappingTable.json");
+ 
+ var PROCESSING_OPTIONS = {

--- a/patches/uri-js+4.4.1.patch
+++ b/patches/uri-js+4.4.1.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/uri-js/dist/esnext/schemes/mailto.js b/node_modules/uri-js/dist/esnext/schemes/mailto.js
+index 2553713..df0ecfd 100755
+--- a/node_modules/uri-js/dist/esnext/schemes/mailto.js
++++ b/node_modules/uri-js/dist/esnext/schemes/mailto.js
+@@ -1,5 +1,5 @@
+ import { pctEncChar, pctDecChars, unescapeComponent } from "../uri";
+-import punycode from "punycode";
++import punycode from "punycode/";
+ import { merge, subexp, toUpperCase, toArray } from "../util";
+ const O = {};
+ const isIRI = true;
+diff --git a/node_modules/uri-js/dist/esnext/uri.js b/node_modules/uri-js/dist/esnext/uri.js
+index 659ce26..1806aa5 100755
+--- a/node_modules/uri-js/dist/esnext/uri.js
++++ b/node_modules/uri-js/dist/esnext/uri.js
+@@ -34,7 +34,7 @@
+  */
+ import URI_PROTOCOL from "./regexps-uri";
+ import IRI_PROTOCOL from "./regexps-iri";
+-import punycode from "punycode";
++import punycode from "punycode/";
+ import { toUpperCase, typeOf, assign } from "./util";
+ export const SCHEMES = {};
+ export function pctEncChar(chr) {

--- a/patches/whatwg-url+5.0.0.patch
+++ b/patches/whatwg-url+5.0.0.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/whatwg-url/lib/url-state-machine.js b/node_modules/whatwg-url/lib/url-state-machine.js
+index c25dbc2..8c2d955 100644
+--- a/node_modules/whatwg-url/lib/url-state-machine.js
++++ b/node_modules/whatwg-url/lib/url-state-machine.js
+@@ -1,5 +1,5 @@
+ "use strict";
+-const punycode = require("punycode");
++const punycode = require("punycode/");
+ const tr46 = require("tr46");
+ 
+ const specialSchemes = {


### PR DESCRIPTION
use `patch-package` to patch `punycode` require/import 

removing this deprecation message:

```shell
[DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```