### PR TITLE
fix path-rewrite-bug

### DIFF
--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -8,7 +8,7 @@ import { verifyConfig } from './configuration';
 import { Debug as debug } from './debug';
 import { getPlugins } from './get-plugins';
 import { getLogger } from './logger';
-import { matchPathFilter } from './path-filter';
+import { matchPathFilter,getUrlPathName } from './path-filter';
 import * as PathRewriter from './path-rewriter';
 import * as Router from './router';
 import type { Filter, Logger, Options, RequestHandler } from './types';
@@ -175,7 +175,8 @@ export class HttpProxyMiddleware<TReq, TRes> {
   // rewrite path
   private applyPathRewrite = async (req: http.IncomingMessage, pathRewriter) => {
     if (pathRewriter) {
-      const path = await pathRewriter(req.url, req);
+      const reqPath = getUrlPathName(req.url);
+      const path = await pathRewriter(reqPath, req);
 
       if (typeof path === 'string') {
         debug('pathRewrite new path: %s', req.url);

--- a/src/path-filter.ts
+++ b/src/path-filter.ts
@@ -87,7 +87,7 @@ function matchMultiPath(pathFilterList: string[], uri?: string) {
  * @param  {String} uri from req.url
  * @return {String}     RFC 3986 path
  */
-function getUrlPathName(uri?: string) {
+export function getUrlPathName(uri?: string) {
   return uri && url.parse(uri).pathname;
 }
 


### PR DESCRIPTION
Fix Path Rewrite Issue with curl -x Proxy AND nginx check

## Description

When using curl -x to send requests through a proxy, the path-rewrite functionality does not work as expected. This issue arises because the proxy server does not correctly handle the path rewriting rules specified in the request.

## Motivation and Context

When sending a request through a proxy using curl -x, the path-rewrite rules defined in the request are not applied. This results in the request being sent to the target server with the original path, rather than the rewritten path.
## How has this been tested?
configuration like this
```
let hsOptions = {
    target: 'http://127.0.0.1:9000/hs',
    changeOrigin: true,
    logLevel: 'debug',
    ws: false,
    pathRewrite: {
      '^/hs' : ''
    }
}
let hsProxy = proxy('/hs', hsOptions)
app.use(hsProxy);
```

then start the node with 80 port

curl -x http://127.0.0.1:80  http://test.domain.com/hs

In this example, the request should be rewritten to http://127.0.0.1:9000/hs, but instead, it is sent as http://127.0.0.1:9000/hs/hs.
##  solution
before path-rewrite, parse the full url, get the real path inestead of the url

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
