### PR TITLE
fix(router): securely check path for proper destination

### DIFF
--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -157,5 +157,19 @@ describe('router unit test', () => {
         return expect(result).resolves.toBe('http://localhost:6006');
       });
     });
+
+    describe('exact path tests, rather than partial match', () => {
+      it('should NOT match route key from query string parameters', () => {
+        fakeReq.url = '/foobar?a=1&b=/rest';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should match from the start of the path and not a substring', () => {
+        fakeReq.url = '/some/path/that/also/contains/rest';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBe('http://localhost:6007');
+      });
+    });
   });
 });


### PR DESCRIPTION
The router previously checked whether a path contained a route key. This check was insufficient, as it allowed a route configured as such:
    '/admin': 'http://localhost:4002',
to be accessed to be accessible by requesting `/some/public/path?q=/admin`, which would match and route the request to localhost:4002.

If http-proxy-middleware is in front of a firewall which restricts access to /admin, this could have allowed unauthorized access to the admin route.

---

Given the following options:

```
const proxyOptions = {
  target: 'http://localhost:4001',
  changeOrigin: true,
  router: {
    '/admin': 'http://localhost:4002',
  },
  on: {
    proxyReq: (proxyReq, req, res) => {
      const targetHost = proxyReq.host;
      console.log(`[PROXY] Request for "${req.originalUrl}" is being routed to -> ${targetHost}`);
    },
  },
};

const proxy = createProxyMiddleware(proxyOptions);
```

it was previously possible to run `curl 'http://localhost:3000/some/public/path?q=/admin` to access the `/admin` endpoint.

## How has this been tested?

Added testcases + manually.


- [x] Bug fix (non-breaking change which fixes an issue)