### PR TITLE
chore(ipv6): only run ipv6 e2e test in ipv6 environment

### DIFF
--- a/test/e2e/ipv6.spec.ts
+++ b/test/e2e/ipv6.spec.ts
@@ -3,9 +3,9 @@ import { getLocal } from 'mockttp';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { createApp, createProxyMiddleware } from './test-kit.js';
+import { createApp, createProxyMiddleware, isIPv6Available } from './test-kit.js';
 
-describe('ipv6 integration', () => {
+describe.runIf(await isIPv6Available())('ipv6 integration', () => {
   let targetServer: Mockttp;
 
   beforeEach(async () => {

--- a/test/e2e/test-kit.ts
+++ b/test/e2e/test-kit.ts
@@ -1,3 +1,5 @@
+import { createServer } from 'node:net';
+
 import express, { type Express, type RequestHandler } from 'express';
 
 export {
@@ -17,4 +19,22 @@ export function createAppWithPath(path: string | string[], middleware: RequestHa
   const app = express();
   app.use(path, middleware);
   return app;
+}
+
+/**
+ * Detects if the current environment supports IPv6
+ * Used to conditionally run tests that require IPv6 support
+ */
+export async function isIPv6Available(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+
+    const done = (result: boolean) => {
+      server.removeAllListeners('error');
+      server.close(() => resolve(result));
+    };
+
+    server.once('error', () => done(false));
+    server.listen(0, '::1', () => done(true));
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability: IPv6 integration tests now run only on systems that support IPv6, preventing spurious failures on non‑IPv6 environments.
  * Added a runtime availability check so the IPv6 test suite is conditionally registered and executed based on detected IPv6 support, reducing false negatives in CI and local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->