### PR TITLE
chore(package.json): bump httpxy to ^0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix: applyPathRewrite logs old req.url instead of rewritten path (#1157)
 - feat(hono): support for hono with createHonoProxyMiddleware
 - feat(ipv6): support literal IPv6 addresses in `target` and `forward` options (ie. "http://[::1]:8000")
+- chore(package.json): bump httpxy to ^0.5.1
 
 ## [v3.0.5](https://github.com/chimurai/http-proxy-middleware/releases/tag/v3.0.5)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-proxy-middleware",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "description": "The one-liner node.js proxy middleware for connect, express, next.js and more",
   "keywords": [
     "browser-sync",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "debug": "^4.4.3",
-    "httpxy": "^0.5.0",
+    "httpxy": "^0.5.1",
     "is-glob": "^4.0.3",
     "is-plain-obj": "^4.1.0",
     "micromatch": "^4.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,10 +2521,10 @@ https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
-httpxy@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/httpxy/-/httpxy-0.5.0.tgz#a9c53543760dee498611827a464e56e14639c0d0"
-  integrity sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg==
+httpxy@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/httpxy/-/httpxy-0.5.1.tgz#c0cccd78672995968eee57666c3e3cfa822c2806"
+  integrity sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==
 
 husky@9.1.7:
   version "9.1.7"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 4.0.0-beta.4
  * Dependency updates for enhanced stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->