### PR TITLE
refactor(package): subpath 'http-proxy-middleware/hono'

### DIFF
--- a/examples/hono/index.js
+++ b/examples/hono/index.js
@@ -6,7 +6,7 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import open from 'open';
 
-import { createHonoProxyMiddleware } from '#http-proxy-middleware';
+import { createHonoProxyMiddleware } from '#http-proxy-middleware/hono';
 
 const app = new Hono();
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,8 @@
   "author": "chimurai",
   "type": "module",
   "imports": {
-    "#http-proxy-middleware": "./subpath.shim.js"
+    "#http-proxy-middleware": "./subpath.shim.js",
+    "#http-proxy-middleware/hono": "./subpath.hono.shim.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/examples/subpath.hono.shim.js
+++ b/examples/subpath.hono.shim.js
@@ -1,0 +1,4 @@
+/**
+ * Shim for examples that need the Hono-specific public subpath.
+ */
+export * from '../dist/index-hono.js';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./hono": {
+      "types": "./dist/index-hono.d.ts",
+      "import": "./dist/index-hono.js",
+      "default": "./dist/index-hono.js"
     }
   },
   "publishConfig": {

--- a/recipes/servers.md
+++ b/recipes/servers.md
@@ -141,7 +141,7 @@ export const config = {
 ```javascript
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
-import { createHonoProxyMiddleware } from 'http-proxy-middleware';
+import { createHonoProxyMiddleware } from 'http-proxy-middleware/hono';
 
 const app = new Hono();
 

--- a/src/factory-hono.ts
+++ b/src/factory-hono.ts
@@ -17,11 +17,13 @@ import { getLogger } from './logger.js';
  * ```ts
  * import { serve } from '@hono/node-server';
  * import { Hono } from 'hono';
- * import { createHonoProxyMiddleware } from 'http-proxy-middleware';
+ * import { createHonoProxyMiddleware } from 'http-proxy-middleware/hono';
  *
  * const app = new Hono();
  * app.use('/api', createHonoProxyMiddleware({ target: 'http://example.com', changeOrigin: true }));
  * serve(app);
+ *
+ * @since 4.0.0
  */
 export function createHonoProxyMiddleware(
   options: Options,

--- a/src/index-hono.ts
+++ b/src/index-hono.ts
@@ -1,0 +1,10 @@
+/**
+ * Hono-specific API entrypoint.
+ *
+ * This is intentionally published as a dedicated subpath (`http-proxy-middleware/hono`)
+ * so the root package types do not import `hono` / `@hono/node-server`.
+ *
+ * Keeping these exports out of the root entrypoint prevents non-Hono consumers from
+ * getting TypeScript module-resolution errors for optional Hono dependencies.
+ */
+export { createHonoProxyMiddleware } from './factory-hono.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export * from './factory.js';
-export * from './factory-hono.js';
 
 export * from './handlers/index.js';
 

--- a/test/e2e/test-kit.ts
+++ b/test/e2e/test-kit.ts
@@ -2,12 +2,9 @@ import { createServer } from 'node:net';
 
 import express, { type Express, type RequestHandler } from 'express';
 
-export {
-  createProxyMiddleware,
-  createHonoProxyMiddleware,
-  responseInterceptor,
-  fixRequestBody,
-} from '../../src/index.js';
+export { createProxyMiddleware, responseInterceptor, fixRequestBody } from '../../src/index.js';
+
+export { createHonoProxyMiddleware } from '../../src/index-hono.js';
 
 export function createApp(...middlewares: RequestHandler[]): Express {
   const app = express();


### PR DESCRIPTION
fixes: #1219
fixes: https://github.com/web-infra-dev/rspack/pull/13883

```shell
Error: node_modules/.../http-proxy-middleware/index.d.ts(8,30): error TS2307: Cannot find module '@hono/node-server' or its corresponding type declarations.
Error: node_modules/.../http-proxy-middleware/index.d.ts(9,35): error TS2307: Cannot find module 'hono' or its corresponding type declarations.
```

---

Separate package `'http-proxy-middleware/hono'` subpath export

```ts
import { createHonoProxyMiddleware } from 'http-proxy-middleware/hono';
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `http-proxy-middleware/hono` subpath export, enabling developers to import and use Hono-specific proxy middleware independently.

* **Documentation**
  * Updated example server applications and official documentation recipes to demonstrate usage of the new Hono subpath import path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->