### PR TITLE
chore(package.json): v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## next
+## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 
 - fix(types): fix Logger type
 - fix(error-response-plugin): sanitize input

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-proxy-middleware",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0",
   "description": "The one-liner node.js proxy middleware for connect, express, next.js and more",
   "keywords": [
     "browser-sync",


### PR DESCRIPTION
fixes: https://github.com/chimurai/http-proxy-middleware/issues/1177

## Notable changes

- Switched proxy from `http-proxy` to `httpxy`
This replaces a long-standing core dependency and brings in many upstream fixes and behavior improvements documented by the `httpxy` project: https://github.com/unjs/httpxy/issues/2.

- ESM-only package
`http-proxy-middleware` now ships as native ES modules only. CommonJS `require()` usage is no longer supported, so imports should use ESM syntax.

- Updated Node.js support policy
Dropped Node.js 14, 16, 18, and 20.
New minimum supported runtime is Node.js 22.15.0

- Removed `legacyCreateProxyMiddleware()`
The legacy compatibility wrapper has been removed as part of API cleanup. Use `createProxyMiddleware()` directly.

- Added IPv6 literal support
`target` and `forward` now support literal IPv6 URLs, for example: `http://[::1]:3000`.

- Experimental Hono support
Added `createHonoProxyMiddleware()` for Hono apps, including dedicated subpath support via `http-proxy-middleware/hono`.

Many thanks to everyone who helped make this release possible. 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to v4.0.0 (stable release)
  * Changelog updated with v4.0.0 release information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->