### PR TITLE
ci(ci.yml): add permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: ['push', 'pull_request']
 
+permissions:
+  contents: read
+
 jobs:
   dependencies:
     name: Dependencies


### PR DESCRIPTION
Add an explicit `permissions` block at the workflow root (right after `on:`) so all jobs inherit least-privilege defaults unless they override them.  
For this workflow, the minimal safe baseline recommended by CodeQL is:

- `contents: read`

This preserves current functionality for common CI tasks like checkout/build/lint/test while ensuring token scope is explicitly constrained. If any omitted jobs later need write scopes, those should be added narrowly at the specific job level, not globally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to explicitly restrict access to read-only, enhancing security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->