### PR TITLE
fix(types): widen Filter callback return type

### DIFF
--- a/src/path-filter.ts
+++ b/src/path-filter.ts
@@ -36,7 +36,7 @@ export function matchPathFilter<TReq extends http.IncomingMessage = http.Incomin
   // custom matching
   if (typeof pathFilter === 'function') {
     const pathname = getUrlPathName(uri) as string;
-    return pathFilter(pathname, req as TReq);
+    return Boolean(pathFilter(pathname, req as TReq));
   }
 
   throw new Error(ERRORS.ERR_CONTEXT_MATCHER_GENERIC);

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface RequestHandler<
 export type Filter<TReq extends http.IncomingMessage = http.IncomingMessage> =
   | string
   | string[]
-  | ((pathname: string, req: TReq) => boolean);
+  | ((pathname: string, req: TReq) => unknown);
 
 /**
  * @see {@link https://github.com/chimurai/http-proxy-middleware/tree/master#defineplugin-helper `definePlugin()`} to define a http-proxy-middleware plugin.

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface RequestHandler<
 export type Filter<TReq extends http.IncomingMessage = http.IncomingMessage> =
   | string
   | string[]
-  | ((pathname: string, req: TReq) => unknown);
+  | ((pathname: string, req: TReq) => boolean | string | RegExpMatchArray | null);
 
 /**
  * @see {@link https://github.com/chimurai/http-proxy-middleware/tree/master#defineplugin-helper `definePlugin()`} to define a http-proxy-middleware plugin.

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -52,6 +52,24 @@ describe('http-proxy-middleware TypeScript Types', () => {
       expect(proxy).toBeDefined();
     });
 
+    it('should create proxy with truthy filter', () => {
+      const proxy = middleware({
+        ...options,
+        pathFilter: (path, req) => path.match('^/api') && req.method === 'GET',
+      });
+      expect(proxy).toBeDefined();
+    });
+
+    it('should create proxy with truthy regex match filter', () => {
+      const proxy = middleware({ ...options, pathFilter: (path, req) => path.match('^/api') });
+      expect(proxy).toBeDefined();
+    });
+
+    it('should create proxy with truthy regex test filter', () => {
+      const proxy = middleware({ ...options, pathFilter: (path, req) => /^\/api/.test(path) });
+      expect(proxy).toBeDefined();
+    });
+
     it('should create proxy with manual websocket upgrade function', () => {
       const proxy = middleware({ ...options, pathFilter: (path, req) => true });
       expect(proxy.upgrade).toBeDefined();


### PR DESCRIPTION
## Description

Widen the `Filter` callback return type from `boolean` to `unknown`, and coerce to `boolean` at the single internal call site in `matchPathFilter` so its public `: boolean` return contract is preserved.

`src/types.ts`:

```diff
-  | ((pathname: string, req: TReq) => boolean);
+  | ((pathname: string, req: TReq) => unknown);
```

`src/path-filter.ts`:

```diff
-    return pathFilter(pathname, req as TReq);
+    return Boolean(pathFilter(pathname, req as TReq));
```

## Motivation and Context

The declared `Filter` callback return type is narrower than what the implementation accepts and what the test suite documents.

The README's own example for the function form of `pathFilter` does not satisfy the declared type:

```js
return path.match('^/api') && req.method === 'GET';
```

`String.prototype.match` returns `RegExpMatchArray | null`, so the expression evaluates to `RegExpMatchArray | null | boolean`. TypeScript users copying this example get a compile error and have to add a manual `Boolean(...)` the runtime doesn't require. The same example is in `recipes/pathFilter.md`.

`test/unit/path-filter.spec.ts` also asserts `'true'`, `''`, and `undefined` as valid filter return values via `toBeTruthy()` / `toBeFalsy()` — confirming the truthy/falsy contract is intentional.

`unknown` is the right type because every narrower option fails:

- `boolean` — rejected by the README example and the string/`undefined` test cases.
- `boolean | null | undefined` — still rejects the string returns the tests cover.
- `boolean | string | null | undefined` — arbitrary; numbers and objects are equally truthy-checkable.
- `any` — strictly worse than `unknown`.

## How has this been tested?

`yarn build` and `yarn test` pass locally with no changes to existing tests. The behavior covered by `test/unit/path-filter.spec.ts` ("Use function for matching" — truthy/falsy) is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Path filter callbacks now accept non-boolean return values (e.g., strings, regex matches, null) and coerce them to boolean, improving compatibility with varied filter implementations.

* **Tests**
  * Added type-level tests covering multiple truthy path-filter return scenarios to validate expected behavior across return types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1232)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->