### PR TITLE
test(logger): add e2e test for ENOTFOUND error log

### DIFF
--- a/src/plugins/default/logger-plugin.ts
+++ b/src/plugins/default/logger-plugin.ts
@@ -26,7 +26,7 @@ export const loggerPlugin: Plugin = definePlugin<FrameworkRequest>((proxyServer,
   proxyServer.on('error', (err, req, res, target?) => {
     const hostname = req?.headers?.host;
     const requestHref = `${hostname}${req?.url}`;
-    const targetHref = `${(target as unknown as any)?.href}`; // target is undefined when websocket errors
+    const targetHref = `${(target as unknown as URL)?.href}`; // target is undefined when websocket errors
 
     const errorMessage = '[HPM] Error occurred while proxying request %s to %s [%s] (%s)';
     const errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors'; // link to Node Common Systems Errors page

--- a/test/e2e/logger.spec.ts
+++ b/test/e2e/logger.spec.ts
@@ -1,0 +1,39 @@
+import { format } from 'node:util';
+
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '../../src/types.js';
+import { createApp, createProxyMiddleware } from './test-kit.js';
+
+describe('logger', () => {
+  it('should log target ENOTFOUND errors', async () => {
+    const logger: Logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const agent = request(
+      createApp(
+        createProxyMiddleware({
+          target: 'http://does-not-exist.invalid',
+          logger,
+        }),
+      ),
+    );
+
+    await agent.get('/my-path').set('Host', 'example.test').expect(504);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    const [message, requestHref, targetHref, errorCode, errorReference] = vi.mocked(logger.error)
+      .mock.calls[0];
+
+    expect(
+      format(message, requestHref, targetHref, errorCode, errorReference),
+    ).toMatchInlineSnapshot(
+      `"[HPM] Error occurred while proxying request example.test/my-path to http://does-not-exist.invalid/ [ENOTFOUND] (https://nodejs.org/api/errors.html#errors_common_system_errors)"`,
+    );
+  });
+});


### PR DESCRIPTION
add missing e2e logger test for ENOTFOUND

related: https://github.com/unjs/httpxy/pull/135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved proxy error logging to handle undefined targets more precisely and ensure consistent log output.

* **Tests**
  * Added an end-to-end test that simulates a failing proxy target, verifies a 504 response, and asserts the logger records the connection error details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->