### PR TITLE
Fix: only create the buffer once in responseInterceptor, fixes #929

### DIFF
--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -47,15 +47,19 @@ export function responseInterceptor<
   ): Promise<void> {
     debug('intercept proxy response');
     const originalProxyRes = proxyRes;
-    let buffer = Buffer.from('', 'utf8');
+    let buffers: Buffer[] = [];
 
     // decompress proxy response
     const _proxyRes = decompress(proxyRes, proxyRes.headers['content-encoding']);
 
     // concat data stream
-    _proxyRes.on('data', (chunk) => (buffer = Buffer.concat([buffer, chunk])));
+    _proxyRes.on('data', (chunk) => buffers.push(chunk));
 
     _proxyRes.on('end', async () => {
+      // Concatenate all buffers into one and free up temp buffers
+      const buffer = buffers.length ? Buffer.concat(buffers) : Buffer.from('', 'utf8');
+      buffers = [];
+
       // copy original headers
       copyHeaders(proxyRes, res);
 
@@ -73,6 +77,7 @@ export function responseInterceptor<
     });
 
     _proxyRes.on('error', (error) => {
+      buffers = [];
       res.end(`Error fetching proxied request: ${error.message}`);
     });
   };


### PR DESCRIPTION
## Description

As described in #929, the old code has a serious performance issue:

```
_proxyRes.on('data', (chunk) => (buffer = Buffer.concat([buffer, chunk])));
```

This recreates a new buffer from the previous buffer for every chunk. Additionally the copied previous buffer is larger for every chunk so this gives exponentially worse performance the larger the buffer.

## Motivation and Context

Logging from old code:
```
1779358511730 HTTPPM intercepting response
1779358511732 HTTPPM chunk len 16384
1779358517866 HTTPPM sending intercepted, len 25246241
-->
total time = 6136 millis
number of buffer rewrites and concats = 1541
```

Logging from new code:
```
1779359112361 HTTPPM intercepting response
1779359112363 HTTPPM chunk len 16384
1779359112556 HTTPPM sending intercepted, len 25246243
-->
total time = 195 millis
number of buffer rewrites and concats = 1
```

## How has this been tested?

Test suite still passes (at least - as well as it did before - ipv6 tests fail on my machine before and after).
Build has been run and manual testing of new JS performed to prove the buffering works correctly.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

No other updates are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized response data handling for improved performance and memory efficiency during proxy operations.
  * Enhanced error recovery with proper resource cleanup in error conditions.

* **Chores**
  * Temporarily adjusted build output handling to accommodate a transitional merge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->