### PR TITLE
fix(ws): handle multi-server upgrade subscription and safe proxy shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix(ipv6): preserve credentials when normalizing bracketed IPv6 target string
 - fix(ipv6): unspecified IPv6 target hostname (::)"
 - fix(response-interceptor): reduce responseInterceptor buffer churn
+- fix(ws): handle multi-server upgrade subscription and safe proxy shutdown
 
 ## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -19,8 +19,8 @@ export class HttpProxyMiddleware<
   TReq extends http.IncomingMessage = http.IncomingMessage,
   TRes extends http.ServerResponse = http.ServerResponse,
 > {
-  private wsInternalSubscribed = false;
-  private serverOnCloseSubscribed = false;
+  private wsInternalSubscribedServers = new WeakSet<http.Server | https.Server>();
+  private activeServers = new Set<http.Server | https.Server>();
   private proxyOptions: Options<TReq, TRes>;
   private proxy: ProxyServer<TReq, TRes>;
   private pathRewriter: ReturnType<typeof createPathRewriter<TReq>>;
@@ -41,10 +41,16 @@ export class HttpProxyMiddleware<
     // https://github.com/chimurai/http-proxy-middleware/issues/19
     // expose function to upgrade externally
     this.middleware.upgrade = (req, socket, head) => {
-      if (!this.wsInternalSubscribed) {
+      const server = this.#getServer(req);
+
+      if (server && !this.wsInternalSubscribedServers.has(server)) {
         this.handleUpgrade(req, socket, head);
       }
     };
+  }
+
+  #getServer(req: TReq): http.Server | https.Server | undefined {
+    return (req.socket as net.Socket & { server?: http.Server | https.Server })?.server;
   }
 
   // https://github.com/Microsoft/TypeScript/wiki/'this'-in-TypeScript#red-flags-for-this
@@ -91,16 +97,24 @@ export class HttpProxyMiddleware<
      * Get the server object to subscribe to server events;
      * 'upgrade' for websocket and 'close' for graceful shutdown
      */
-    const server = (req.socket as net.Socket & { server?: https.Server })?.server;
+    const server = this.#getServer(req);
 
-    if (server && !this.serverOnCloseSubscribed) {
+    if (server && !this.activeServers.has(server)) {
+      debug('registering server close listener');
+      this.activeServers.add(server);
+
       server.on('close', () => {
-        debug('server close signal received: closing proxy server');
-        this.proxy.close(() => {
-          debug('proxy server closed');
-        });
+        debug('server close signal received.');
+        this.activeServers.delete(server);
+
+        if (this.activeServers.size > 0) {
+          debug(`proxy server not closed: ${this.activeServers.size} server(s) still active`);
+          return;
+        } else {
+          debug('closing proxy server');
+          this.proxy.close(() => debug('proxy server closed'));
+        }
       });
-      this.serverOnCloseSubscribed = true;
     }
 
     if (this.proxyOptions.ws === true && server) {
@@ -117,13 +131,11 @@ export class HttpProxyMiddleware<
     });
   }
 
-  private catchUpgradeRequest = (server: https.Server) => {
-    if (!this.wsInternalSubscribed) {
+  private catchUpgradeRequest = (server: http.Server | https.Server) => {
+    if (!this.wsInternalSubscribedServers.has(server)) {
       debug('subscribing to server upgrade event');
       server.on('upgrade', this.handleUpgrade);
-      // prevent duplicate upgrade handling;
-      // in case external upgrade is also configured
-      this.wsInternalSubscribed = true;
+      this.wsInternalSubscribedServers.add(server);
     }
   };
 

--- a/test/e2e/graceful-shutdown.spec.ts
+++ b/test/e2e/graceful-shutdown.spec.ts
@@ -88,4 +88,32 @@ describe('E2E graceful shutdown', () => {
     // proxy.close() should still be called exactly once
     expect(proxyCloseSpy).toHaveBeenCalledOnce();
   });
+
+  it('should close proxy only after all attached servers close', async () => {
+    const proxyMiddleware = createProxyMiddleware({ target: mockTargetServer.url });
+    const app = createApp(proxyMiddleware);
+
+    const proxyServerA = http.createServer(app);
+    const proxyServerB = http.createServer(app);
+    const serverPortA = await getPort();
+    const serverPortB = await getPort();
+
+    await Promise.all([
+      new Promise<void>((resolve) => proxyServerA.listen(serverPortA, resolve)),
+      new Promise<void>((resolve) => proxyServerB.listen(serverPortB, resolve)),
+    ]);
+
+    expect(capturedProxy).toBeDefined();
+    const proxyCloseSpy = vi.spyOn(capturedProxy!, 'close');
+
+    // Attach middleware listeners to both servers
+    await request(`http://localhost:${serverPortA}`).get('/api').expect(200);
+    await request(`http://localhost:${serverPortB}`).get('/api').expect(200);
+
+    await closeServer(proxyServerA);
+    expect(proxyCloseSpy).not.toHaveBeenCalled();
+
+    await closeServer(proxyServerB);
+    expect(proxyCloseSpy).toHaveBeenCalledOnce();
+  });
 });

--- a/test/e2e/websocket.spec.ts
+++ b/test/e2e/websocket.spec.ts
@@ -141,6 +141,56 @@ describe('E2E WebSocket proxy', () => {
     });
   });
 
+  describe('option.ws across multiple servers', () => {
+    it('should proxy websocket upgrades on every attached server', async () => {
+      const serverPortA = await getPort();
+      const serverPortB = await getPort();
+
+      const proxyServerA = createApp(proxyMiddleware).listen(serverPortA);
+      const proxyServerB = createApp(proxyMiddleware).listen(serverPortB);
+
+      const connectWebSocketWithTimeout = (url: string) => {
+        return new Promise<void>((resolve, reject) => {
+          const socket = new WebSocket(url);
+          const timeout = setTimeout(() => {
+            socket.terminate();
+            reject(new Error(`Timed out connecting to ${url}`));
+          }, 2000);
+
+          socket.once('open', () => {
+            clearTimeout(timeout);
+            socket.close();
+            resolve();
+          });
+
+          socket.once('error', (error) => {
+            clearTimeout(timeout);
+            reject(error);
+          });
+        });
+      };
+
+      try {
+        await new Promise((resolve, reject) => {
+          http.get(`http://localhost:${serverPortA}/`, resolve).on('error', reject);
+        });
+
+        await new Promise((resolve, reject) => {
+          http.get(`http://localhost:${serverPortB}/`, resolve).on('error', reject);
+        });
+
+        await expect(
+          connectWebSocketWithTimeout(`ws://localhost:${serverPortA}/socket`),
+        ).resolves.toBeUndefined();
+        await expect(
+          connectWebSocketWithTimeout(`ws://localhost:${serverPortB}/socket`),
+        ).resolves.toBeUndefined();
+      } finally {
+        await Promise.all([closeServer(proxyServerA), closeServer(proxyServerB)]);
+      }
+    });
+  });
+
   describe('with router and pathRewrite', () => {
     beforeEach(() => {
       const proxyMiddleware = createProxyMiddleware({


### PR DESCRIPTION
fixes: #1149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket upgrade requests are now correctly handled when multiple HTTP servers use the same proxy middleware.
  * Graceful proxy shutdown now properly tracks multiple server instances and defers closure until all servers have closed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->