### PR TITLE
ci(publish.yml): npm stage publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
       id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
@@ -29,8 +31,8 @@ jobs:
 
       - name: Publish to NPM (beta)
         if: 'github.event.release.prerelease'
-        run: npm publish --access public --tag beta
+        run: npm stage publish --access public --tag beta
 
       - name: Publish to NPM (stable)
         if: '!github.event.release.prerelease'
-        run: npm publish --access public
+        run: npm stage publish --access public


### PR DESCRIPTION
Use `npm stage publish` in `publish.yml`

https://github.blog/changelog/2026-05-22-staged-publishing-and-new-install-time-controls-for-npm/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm publishing workflow configuration to use token-based authentication for package publishing.
  * Modified the publish command in the continuous deployment process for both beta and stable releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->