### PR TITLE
fix(responseInterceptor): prevent trailer/content-length conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fix(ws): handle multi-server upgrade subscription and safe proxy shutdown
 - feat(router): add 'res' and 'options' to router function
 - feat(pathRewrite): add 'res' and 'options' to custom pathRewrite function
+- fix(responseInterceptor): prevent trailer/content-length conflict
 
 ## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 

--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -74,6 +74,11 @@ export function responseInterceptor<
 
       // set correct content-length (with double byte character support)
       debug('set content-length: %s', Buffer.byteLength(interceptedBuffer));
+
+      // Buffered responses cannot preserve trailer framing.
+      // Remove trailer declaration (and transfer-encoding just in case) before setting content-length.
+      res.removeHeader('trailer');
+      res.removeHeader('transfer-encoding');
       res.setHeader('content-length', Buffer.byteLength(interceptedBuffer));
 
       debug('write intercepted response');
@@ -143,8 +148,10 @@ function copyHeaders<TRes extends http.ServerResponse = http.ServerResponse>(
   if (response.setHeader) {
     let keys = Object.keys(originalResponse.headers);
 
-    // ignore chunked, brotli, gzip, deflate headers
-    keys = keys.filter((key) => !['content-encoding', 'transfer-encoding'].includes(key));
+    // ignore encoding/framing headers that are incompatible with buffered interception
+    keys = keys.filter(
+      (key) => !['content-encoding', 'transfer-encoding', 'trailer'].includes(key),
+    );
 
     keys.forEach((key) => {
       let value = originalResponse.headers[key];

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -157,4 +157,49 @@ describe('responseInterceptor()', () => {
       expect(response.body.deflated).toBe(true);
     });
   });
+
+  describe('trailer response header handling', () => {
+    beforeEach(async () => {
+      await targetServer
+        .forGet('/response-headers')
+        .withExactQuery('?Trailer=X-Stream-Error&Host=localhost')
+        .thenReply(200, '', {
+          'transfer-encoding': 'chunked',
+          trailer: 'X-Stream-Error',
+          host: 'localhost',
+          'set-cookie': 'cookie=monster; Path=/',
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'private, max-age=60',
+        });
+
+      agent = request(
+        createApp(
+          createProxyMiddleware({
+            target: targetServer.url,
+            changeOrigin: true,
+            selfHandleResponse: true,
+            on: {
+              proxyRes: responseInterceptor(async () => {
+                return JSON.stringify({ ok: true, note: 'rewritten' });
+              }),
+            },
+          }),
+        ),
+      );
+    });
+
+    it('should rewrite body without trailer/content-length conflict and preserve end-to-end headers', async () => {
+      const response = await agent
+        .get('/response-headers?Trailer=X-Stream-Error&Host=localhost')
+        .expect(200);
+
+      expect(response.body).toEqual({ ok: true, note: 'rewritten' });
+      expect(response.header['trailer']).toBeUndefined();
+      expect(response.header['transfer-encoding']).toBeUndefined();
+      expect(response.header['content-length']).toBeDefined();
+      expect(response.header['content-type']).toContain('application/json');
+      expect(response.header['set-cookie']).toBeDefined();
+      expect(response.header['cache-control']).toBe('private, max-age=60');
+    });
+  });
 });


### PR DESCRIPTION
Causing this error to be thrown:

```shell
node:_http_outgoing:522
    throw new ERR_HTTP_TRAILER_INVALID();
    ^

Error [ERR_HTTP_TRAILER_INVALID]: Trailers are invalid with this transfer encoding
```

closes #830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxied response header handling to strip incompatible framing headers while preserving content-length, content-type, set-cookie, and cache-control so responses are correctly framed.
* **Tests**
  * Added end-to-end tests covering responses with chunked transfer encoding and trailer headers to verify correct header filtering and body rewriting.
* **Chores**
  * Updated changelog with the fix entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->