### PR TITLE
feat(zstd): support zstd compression in responseInterceptor and fixRequestBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat(router): add 'res' and 'options' to router function
 - feat(pathRewrite): add 'res' and 'options' to custom pathRewrite function
 - fix(responseInterceptor): prevent trailer/content-length conflict
+- feat(zstd): support zstd compression in responseInterceptor and fixRequestBody
 
 ## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 

--- a/cspell.json
+++ b/cspell.json
@@ -55,6 +55,7 @@
     "unstub",
     "vhosted",
     "websockets",
-    "xfwd"
+    "xfwd",
+    "zstd"
   ]
 }

--- a/recipes/response-interceptor.md
+++ b/recipes/response-interceptor.md
@@ -2,7 +2,7 @@
 
 Intercept responses from upstream with `responseInterceptor`. (Make sure to set `selfHandleResponse: true`)
 
-Responses which are compressed with `brotli`, `gzip` and `deflate` will be decompressed automatically. Response will be made available as [`buffer`](https://nodejs.org/api/buffer.html) which you can manipulate.
+Responses which are compressed with `brotli`, `gzip`, `deflate` and `zstd` will be decompressed automatically (zstd requires Node.js >= 22.15.0). Response will be made available as [`buffer`](https://nodejs.org/api/buffer.html) which you can manipulate.
 
 ## Replace text and change http status code
 

--- a/src/handlers/fix-request-body.ts
+++ b/src/handlers/fix-request-body.ts
@@ -56,6 +56,9 @@ export function fixRequestBody<TReq extends BodyParserLikeRequest = BodyParserLi
       case 'gzip':
         proxyData = zlib.gzipSync(proxyData);
         break;
+      case 'zstd':
+        proxyData = zlib.zstdCompressSync(proxyData);
+        break;
     }
 
     proxyReq.setHeader('Content-Length', Buffer.byteLength(proxyData));

--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -15,7 +15,7 @@ type Interceptor<TReq = http.IncomingMessage, TRes = http.ServerResponse> = (
 
 /**
  * Intercept responses from upstream.
- * Automatically decompress (deflate, gzip, brotli).
+ * Automatically decompress (deflate, gzip, brotli, zstd).
  * Give developer the opportunity to modify intercepted Buffer and http.ServerResponse
  *
  * NOTE: must set options.selfHandleResponse=true (prevent automatic call of res.end())
@@ -101,8 +101,9 @@ export function responseInterceptor<
 function decompress<TReq extends http.IncomingMessage = http.IncomingMessage>(
   proxyRes: TReq,
   contentEncoding?: string,
-): TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress {
-  let _proxyRes: TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress = proxyRes;
+): TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress | zlib.ZstdDecompress {
+  let _proxyRes: TReq | zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress | zlib.ZstdDecompress =
+    proxyRes;
   let decompress;
 
   switch (contentEncoding) {
@@ -114,6 +115,9 @@ function decompress<TReq extends http.IncomingMessage = http.IncomingMessage>(
       break;
     case 'deflate':
       decompress = zlib.createInflate();
+      break;
+    case 'zstd':
+      decompress = zlib.createZstdDecompress();
       break;
     default:
       break;

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -128,6 +128,17 @@ describe('responseInterceptor()', () => {
           'content-type': 'application/json; charset=utf-8',
         });
 
+      await targetServer
+        .forGet('/zstd')
+        .thenReply(
+          200,
+          zlib.zstdCompressSync(Buffer.from(JSON.stringify({ zstd: true }), 'utf8')),
+          {
+            'content-encoding': 'zstd',
+            'content-type': 'application/json; charset=utf-8',
+          },
+        );
+
       agent = request(
         createApp(
           createProxyMiddleware({
@@ -155,6 +166,11 @@ describe('responseInterceptor()', () => {
     it('should return decompressed deflated response from /deflate', async () => {
       const response = await agent.get(`/deflate`).expect(200);
       expect(response.body.deflated).toBe(true);
+    });
+
+    it('should return decompressed zstd response from /zstd', async () => {
+      const response = await agent.get(`/zstd`).expect(200);
+      expect(response.body.zstd).toBe(true);
     });
   });
 

--- a/test/unit/fix-request-body.spec.ts
+++ b/test/unit/fix-request-body.spec.ts
@@ -187,4 +187,17 @@ describe('fixRequestBody', () => {
     expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
     expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
   });
+
+  it('should re-encode body when the source was zstd encoded', () => {
+    const proxyRequest = fakeProxyRequest();
+    proxyRequest.setHeader('content-type', 'application/json; charset=utf-8');
+    proxyRequest.setHeader('content-encoding', 'zstd');
+
+    const data = { someField: 'some value' };
+    fixRequestBody(proxyRequest, createRequestWithBody(data));
+
+    const expectedBody = zlib.zstdCompressSync(JSON.stringify(data));
+    expect(proxyRequest.setHeader).toHaveBeenCalledWith('Content-Length', expectedBody.length);
+    expect(proxyRequest.write).toHaveBeenCalledWith(expectedBody);
+  });
 });


### PR DESCRIPTION
closes #1106
fixes #1070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zstandard (zstd) compression support for both requests and responses
  * Responses compressed with zstd are now automatically decompressed (requires Node.js ≥ 22.15.0)

* **Documentation**
  * Updated documentation to reflect zstd compression support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->