### PR TITLE
fix(responseInterceptor): handle bodyless responses (HEAD/1xx/204/304) with content-encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - feat(pathRewrite): add 'res' and 'options' to custom pathRewrite function
 - fix(responseInterceptor): prevent trailer/content-length conflict
 - feat(zstd): support zstd compression in responseInterceptor and fixRequestBody
+- fix(responseInterceptor): handle bodyless responses (HEAD/1xx/204/304) with content-encoding
 
 ## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
   ],
   "ignoreRegExpList": ["[a-z]+path", "\\]\\(#[a-z-]+\\)", "%[\\dA-Z]{2}"],
   "words": [
+    "bodyless",
     "brotli",
     "camelcase",
     "codesandbox",

--- a/src/handlers/response-interceptor.ts
+++ b/src/handlers/response-interceptor.ts
@@ -50,8 +50,13 @@ export function responseInterceptor<
     const chunks: Buffer[] = [];
     let bufferLength = 0;
 
+    // Bodyless responses (HEAD, 1xx, 204, 304) must not be decompressed.
+    const contentEncoding = isBodylessResponse(proxyRes.statusCode, req.method)
+      ? undefined
+      : proxyRes.headers['content-encoding'];
+
     // decompress proxy response
-    const _proxyRes = decompress(proxyRes, proxyRes.headers['content-encoding']);
+    const _proxyRes = decompress(proxyRes, contentEncoding);
 
     // collect data chunks and concatenate once on end to avoid repeated full-buffer copies
     _proxyRes.on('data', (chunk) => {
@@ -67,6 +72,13 @@ export function responseInterceptor<
 
       // copy original headers
       copyHeaders(proxyRes, res);
+
+      // RFC 9110: HEAD and 1xx/204/304 responses do not include content.
+      // End the response after headers to avoid writing an invalid body.
+      if (isBodylessResponse(proxyRes.statusCode, req.method)) {
+        res.end();
+        return;
+      }
 
       // call interceptor with intercepted response (buffer)
       debug('call interceptor function: %s', getFunctionName(interceptor));
@@ -92,6 +104,14 @@ export function responseInterceptor<
       res.end(`Error fetching proxied request: ${error.message}`);
     });
   };
+}
+
+function isBodylessResponse(statusCode?: number, method?: string): boolean {
+  return (
+    method?.toUpperCase() === 'HEAD' ||
+    (statusCode !== undefined &&
+      ((statusCode >= 100 && statusCode < 200) || statusCode === 204 || statusCode === 304))
+  );
 }
 
 /**

--- a/test/e2e/response-interceptor.spec.ts
+++ b/test/e2e/response-interceptor.spec.ts
@@ -218,4 +218,47 @@ describe('responseInterceptor()', () => {
       expect(response.header['cache-control']).toBe('private, max-age=60');
     });
   });
+
+  describe('bodyless responses with content-encoding', () => {
+    beforeEach(async () => {
+      await targetServer.forGet('/no-content').thenReply(204, '', {
+        'content-encoding': 'gzip',
+        'cache-control': 'no-cache',
+      });
+
+      await targetServer.forGet('/not-modified').thenReply(304, '', {
+        'content-encoding': 'deflate',
+        etag: '"123"',
+      });
+
+      agent = request(
+        createApp(
+          createProxyMiddleware({
+            target: targetServer.url,
+            changeOrigin: true,
+            selfHandleResponse: true,
+            on: {
+              proxyRes: responseInterceptor(async (buffer) => buffer),
+            },
+          }),
+        ),
+      );
+    });
+
+    it('should preserve 204 and not fail on empty gzip body', async () => {
+      const response = await agent.get('/no-content').expect(204);
+
+      expect(response.text).toBe('');
+      expect(response.header['content-encoding']).toBeUndefined();
+      expect(response.header['cache-control']).toBe('no-cache');
+    });
+
+    it('should preserve 304 and not fail on empty deflate body', async () => {
+      const response = await agent.get('/not-modified').expect(304);
+
+      expect(response.text).toBe('');
+      expect(response.header['content-encoding']).toBeUndefined();
+      expect(response.header.etag).toBe('"123"');
+    });
+  });
 });

--- a/test/unit/response-interceptor.spec.ts
+++ b/test/unit/response-interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { responseInterceptor } from '../../src/handlers/response-interceptor.js';
 import { createMockRequest, createMockResponse } from '../test-utils.js';
@@ -77,5 +77,49 @@ describe('responseInterceptor', () => {
     expect(res.setHeader).not.toHaveBeenCalled();
     expect(res.write).not.toHaveBeenCalled();
     expect(res.end).toHaveBeenCalledWith('Error fetching proxied request: some error message');
+  });
+
+  it('should not write response body for HEAD requests', async () => {
+    const proxyRes = createMockRequest({
+      statusCode: 200,
+      headers: {
+        'content-encoding': 'gzip',
+      },
+    });
+    const req = createMockRequest({ method: 'HEAD' });
+    const res = createMockResponse();
+    const interceptor = vi.fn(async (buffer: Buffer) => buffer);
+
+    responseInterceptor(interceptor)(proxyRes, req, res);
+
+    proxyRes.emit('data', Buffer.from('HPM'));
+    proxyRes.emit('end');
+    await waitInterceptorHandler();
+
+    expect(interceptor).not.toHaveBeenCalled();
+    expect(res.write).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledWith();
+  });
+
+  it('should not write response body for informational responses', async () => {
+    const proxyRes = createMockRequest({
+      statusCode: 103,
+      headers: {
+        'content-encoding': 'gzip',
+      },
+    });
+    const req = createMockRequest({ method: 'GET' });
+    const res = createMockResponse();
+    const interceptor = vi.fn(async (buffer: Buffer) => buffer);
+
+    responseInterceptor(interceptor)(proxyRes, req, res);
+
+    proxyRes.emit('data', Buffer.from('HPM'));
+    proxyRes.emit('end');
+    await waitInterceptorHandler();
+
+    expect(interceptor).not.toHaveBeenCalled();
+    expect(res.write).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalledWith();
   });
 });


### PR DESCRIPTION
fixes: #381
fixes: #658

reproduction:
```ts
const targetServer = http.createServer((req, res) => {
  res.statusCode = 204;
  res.setHeader('content-type', 'application/json; charset=utf-8');
  res.setHeader('content-encoding', 'gzip');
  res.end();
});


const app = express();
app.use(
  '/abc',
  createProxyMiddleware({
    target: targetUrl,
    changeOrigin: true,
    selfHandleResponse: true,
    on: {
      proxyRes: responseInterceptor(async (buffer) => buffer),
    },
  }),
);
```

response:

```json
{
  "status": 200,
  "text": "Error fetching proxied request: unexpected end of file",
  "body": {},
  "headers": {
    "x-powered-by": "Express",
    "date": "Mon, 25 May 2026 10:45:02 GMT",
    "connection": "close",
    "content-length": "54"
  }
}
```

also mentioned in:
- https://github.com/ui5-community/ui5-ecosystem-showcase/issues/905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of bodyless HTTP responses (HEAD, 1xx, 204, 304) when upstream includes content-encoding headers. The response interceptor now correctly removes content-encoding from proxied response headers for these cases.

* **Tests**
  * Added test coverage for bodyless responses with content-encoding headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chimurai/http-proxy-middleware/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->