### PR TITLE
fix(router): harden proxy-table matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(types): fix Logger type
 - fix(error-response-plugin): sanitize input
+- fix(router): harden proxy-table matching (exact host for host+path keys, prefix-only path matching) to prevent routing bypass
 
 ## [v3.0.5](https://github.com/chimurai/http-proxy-middleware/releases/tag/v3.0.5)
 

--- a/cspell.json
+++ b/cspell.json
@@ -47,6 +47,7 @@
     "restream",
     "snyk",
     "streamify",
+    "superstring",
     "trivago",
     "tseslint",
     "typicode",

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,18 +19,28 @@ export async function getTarget(req, config) {
 
 function getTargetFromProxyTable(req, table) {
   let result;
-  const host = req.headers.host;
-  const path = req.url;
-
-  const hostAndPath = host + path;
+  const host = req.headers.host || '';
+  const path = req.url || '';
 
   for (const [key, value] of Object.entries(table)) {
     if (containsPath(key)) {
-      if (hostAndPath.indexOf(key) > -1) {
-        // match 'localhost:3000/api'
-        result = value;
-        debug('match: "%s" -> "%s"', key, result);
-        break;
+      if (isHostAndPathKey(key)) {
+        const [keyHost, keyPath] = splitHostAndPathKey(key);
+
+        // SECURITY: host+path keys must match exact host + path prefix.
+        if (host === keyHost && path.startsWith(keyPath)) {
+          // match 'localhost:3000/api'
+          result = value;
+          debug('match: "%s" -> "%s"', key, result);
+          break;
+        }
+      } else {
+        if (path.startsWith(key)) {
+          // match '/api'
+          result = value;
+          debug('match: "%s" -> "%s"', key, result);
+          break;
+        }
       }
     } else {
       if (key === host) {
@@ -47,4 +57,13 @@ function getTargetFromProxyTable(req, table) {
 
 function containsPath(v) {
   return v.indexOf('/') > -1;
+}
+
+function isHostAndPathKey(v) {
+  return containsPath(v) && !v.startsWith('/');
+}
+
+function splitHostAndPathKey(v) {
+  const firstSlash = v.indexOf('/');
+  return [v.slice(0, firstSlash), v.slice(firstSlash)];
 }

--- a/test/e2e/router.spec.ts
+++ b/test/e2e/router.spec.ts
@@ -1,3 +1,4 @@
+/* spellchecker: ignore evilbeta, evillocalhost */
 import { ErrorRequestHandler } from 'express';
 import * as getPort from 'get-port';
 import { Mockttp, generateCACertificate, getLocal } from 'mockttp';
@@ -185,10 +186,22 @@ describe('E2E router', () => {
       expect(response.text).toBe('B');
     });
 
+    it('should not proxy host-only target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evilbeta.localhost:6000').expect(200);
+
+      expect(response.text).toBe('A');
+    });
+
     it('should proxy with host & path config: "localhost:6000/api"', async () => {
       const response = await agent.get('/api').set('host', 'localhost:6000').expect(200);
 
       expect(response.text).toBe('C');
+    });
+
+    it('should not proxy to host+path target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evillocalhost:6000').expect(200);
+
+      expect(response.text).toBe('A');
     });
   });
 });

--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -1,3 +1,4 @@
+// spell-checker: ignore evilalpha, evilgamma
 import { getTarget } from '../../src/router';
 
 describe('router unit test', () => {
@@ -106,6 +107,12 @@ describe('router unit test', () => {
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6002');
       });
+
+      it('should not match host-only config when host contains key as substring', () => {
+        fakeReq.headers.host = 'evilalpha.localhost';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with host and host + path config', () => {
@@ -128,6 +135,20 @@ describe('router unit test', () => {
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6003');
       });
+
+      it('should not match host+path config when host is a superstring', () => {
+        fakeReq.headers.host = 'evilgamma.localhost';
+        fakeReq.url = '/api';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match host+path config when host only contains host as a substring', () => {
+        fakeReq.headers.host = 'gamma.localhost.evil';
+        fakeReq.url = '/api/books/123';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with just the path', () => {
@@ -145,6 +166,12 @@ describe('router unit test', () => {
 
       it('should target http://localhost:6000 path in not present in router config', () => {
         fakeReq.url = '/unknown-path';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match path config when key appears as non-prefix substring', () => {
+        fakeReq.url = '/prefix/rest';
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBeUndefined();
       });


### PR DESCRIPTION
closes: https://github.com/chimurai/http-proxy-middleware/pull/160
closes: https://github.com/chimurai/http-proxy-middleware/pull/629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened proxy-table matching in the router to prevent routing bypass vulnerabilities by enforcing exact host matches and prefix-only path matching rules.

* **Tests**
  * Added comprehensive E2E and unit test coverage to verify proxy-table host matching security improvements.

* **Documentation**
  * Updated CHANGELOG with details about proxy-table security enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->