### PR TITLE
fix(router): harden proxy-table matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix(responseInterceptor): prevent trailer/content-length conflict
 - feat(zstd): support zstd compression in responseInterceptor and fixRequestBody
 - fix(responseInterceptor): handle bodyless responses (HEAD/1xx/204/304) with content-encoding
+- fix(router): harden proxy-table matching
 
 ## [v4.0.0](https://github.com/chimurai/http-proxy-middleware/releases/tag/v4.0.0)
 

--- a/cspell.json
+++ b/cspell.json
@@ -51,6 +51,7 @@
     "selfsigned",
     "snyk",
     "streamify",
+    "superstring",
     "tseslint",
     "typicode",
     "unstub",

--- a/src/router.ts
+++ b/src/router.ts
@@ -32,15 +32,25 @@ function getTargetFromProxyTable<TReq extends http.IncomingMessage>(
   const host = req.headers.host ?? '';
   const path = req.url ?? '';
 
-  const hostAndPath = host + path;
-
   for (const [key, value] of Object.entries(table)) {
     if (containsPath(key)) {
-      if (hostAndPath.indexOf(key) > -1) {
-        // match 'localhost:3000/api'
-        result = value;
-        debug('match: "%s" -> "%s"', key, result);
-        break;
+      if (isHostAndPathKey(key)) {
+        const [keyHost, keyPath] = splitHostAndPathKey(key);
+
+        // SECURITY: host+path keys must match exact host + path prefix.
+        if (host === keyHost && path.startsWith(keyPath)) {
+          // match 'localhost:3000/api'
+          result = value;
+          debug('match: "%s" -> "%s"', key, result);
+          break;
+        }
+      } else {
+        if (path.startsWith(key)) {
+          // match '/api'
+          result = value;
+          debug('match: "%s" -> "%s"', key, result);
+          break;
+        }
       }
     } else {
       if (key === host) {
@@ -57,4 +67,13 @@ function getTargetFromProxyTable<TReq extends http.IncomingMessage>(
 
 function containsPath(v: string) {
   return v.indexOf('/') > -1;
+}
+
+function isHostAndPathKey(v: string) {
+  return containsPath(v) && !v.startsWith('/');
+}
+
+function splitHostAndPathKey(v: string): [string, string] {
+  const firstSlash = v.indexOf('/');
+  return [v.slice(0, firstSlash), v.slice(firstSlash)];
 }

--- a/test/e2e/router.spec.ts
+++ b/test/e2e/router.spec.ts
@@ -1,3 +1,5 @@
+// spell-checker: ignore evilbeta, evillocalhost
+
 import type { Agent as HttpAgent } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
 
@@ -261,10 +263,22 @@ describe('E2E router', () => {
       expect(response.text).toBe('HTTPS B');
     });
 
+    it('should not proxy host-only target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evilbeta.localhost:6000').expect(200);
+
+      expect(response.text).toBe('HTTPS A');
+    });
+
     it('should proxy with host & path config: "localhost:6000/api"', async () => {
       const response = await agent.get('/api').set('host', 'localhost:6000').expect(200);
 
       expect(response.text).toBe('HTTPS C');
+    });
+
+    it('should not proxy to host+path target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evillocalhost:6000').expect(200);
+
+      expect(response.text).toBe('HTTPS A');
     });
   });
 });

--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -1,3 +1,5 @@
+// spell-checker: ignore evilalpha, evilgamma
+
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -115,6 +117,12 @@ describe('router unit test', () => {
         result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6002');
       });
+
+      it('should not match host-only config when host contains key as substring', () => {
+        mockReq.headers.host = 'evilalpha.localhost';
+        result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with host and host + path config', () => {
@@ -137,6 +145,20 @@ describe('router unit test', () => {
         result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6003');
       });
+
+      it('should not match host+path config when host is a superstring', () => {
+        mockReq.headers.host = 'evilgamma.localhost';
+        mockReq.url = '/api';
+        result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match host+path config when host only contains host as a substring', () => {
+        mockReq.headers.host = 'gamma.localhost.evil';
+        mockReq.url = '/api/books/123';
+        result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with just the path', () => {
@@ -154,6 +176,12 @@ describe('router unit test', () => {
 
       it('should target http://localhost:6000 path in not present in router config', () => {
         mockReq.url = '/unknown-path';
+        result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match path config when key appears as non-prefix substring', () => {
+        mockReq.url = '/prefix/rest';
         result = getTarget(mockReq, mockRes, proxyOptionWithRouter);
         return expect(result).resolves.toBeUndefined();
       });


### PR DESCRIPTION
closes: https://github.com/chimurai/http-proxy-middleware/pull/160
closes: https://github.com/chimurai/http-proxy-middleware/pull/629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy table matching tightened to require exact host and proper path-prefix rules, preventing accidental substring matches.

* **Tests**
  * New unit and end-to-end tests added to cover proxy matching edge cases and superstring host scenarios.

* **Documentation**
  * Changelog updated with the fix entry.

* **Chores**
  * Added "superstring" to the spell-check allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->