### PR TITLE
feat(types): export OnProxyEvent type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export * from './factory.js';
 
 export * from './handlers/index.js';
 
-export type { Plugin, Filter, Options, RequestHandler } from './types.js';
+export type { Plugin, Filter, Options, RequestHandler, OnProxyEvent } from './types.js';
 
 export * from './plugins/index.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expose OnProxyEvent type

## Motivation and Context

We have some OnProxyEvent handlers we build in a sperate file and now need to use `NonNullable<Options<Request, Response>['on']>` for the types. This would make it slightly easier

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `OnProxyEvent` type is now exported and available for public use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->