### PR TITLE
fix: harden proxy-table matching to prevent routing bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- fix(router): harden proxy-table matching (exact host for host+path keys, prefix-only path matching) to prevent routing bypass
+
 ## [v2.0.9](https://github.com/chimurai/http-proxy-middleware/releases/tag/v2.0.9)
 
 - fix(fixRequestBody): check readableLength

--- a/cspell.json
+++ b/cspell.json
@@ -33,6 +33,7 @@
     "rawbody",
     "restream",
     "streamify",
+    "superstring",
     "vhosted",
     "websockets",
     "xfwd"

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,18 +17,28 @@ export async function getTarget(req, config) {
 
 function getTargetFromProxyTable(req, table) {
   let result;
-  const host = req.headers.host;
-  const path = req.url;
-
-  const hostAndPath = host + path;
+  const host = req.headers.host || '';
+  const path = req.url || '';
 
   for (const [key] of Object.entries(table)) {
     if (containsPath(key)) {
-      if (hostAndPath.indexOf(key) > -1) {
-        // match 'localhost:3000/api'
-        result = table[key];
-        logger.debug('[HPM] Router table match: "%s"', key);
-        break;
+      if (isHostAndPathKey(key)) {
+        const [keyHost, keyPath] = splitHostAndPathKey(key);
+
+        // SECURITY: host+path keys must match exact host + path prefix.
+        if (host === keyHost && path.startsWith(keyPath)) {
+          // match 'localhost:3000/api'
+          result = table[key];
+          logger.debug('[HPM] Router table match: "%s"', key);
+          break;
+        }
+      } else {
+        if (path.startsWith(key)) {
+          // match '/api'
+          result = table[key];
+          logger.debug('[HPM] Router table match: "%s"', key);
+          break;
+        }
       }
     } else {
       if (key === host) {
@@ -45,4 +55,13 @@ function getTargetFromProxyTable(req, table) {
 
 function containsPath(v) {
   return v.indexOf('/') > -1;
+}
+
+function isHostAndPathKey(v) {
+  return containsPath(v) && !v.startsWith('/');
+}
+
+function splitHostAndPathKey(v) {
+  const firstSlash = v.indexOf('/');
+  return [v.slice(0, firstSlash), v.slice(firstSlash)];
 }

--- a/test/e2e/router.spec.ts
+++ b/test/e2e/router.spec.ts
@@ -1,3 +1,4 @@
+/* spellchecker: ignore evilbeta, evillocalhost */
 import { createProxyMiddleware, createApp, createAppWithPath } from './test-kit';
 import { ErrorRequestHandler } from 'express';
 import * as request from 'supertest';
@@ -190,10 +191,22 @@ describe('E2E router', () => {
       expect(response.text).toBe('B');
     });
 
+    it('should not proxy host-only target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evilbeta.localhost:6000').expect(200);
+
+      expect(response.text).toBe('A');
+    });
+
     it('should proxy with host & path config: "localhost:6000/api"', async () => {
       const response = await agent.get('/api').set('host', 'localhost:6000').expect(200);
 
       expect(response.text).toBe('C');
+    });
+
+    it('should not proxy to host+path target when host is a crafted superstring', async () => {
+      const response = await agent.get('/api').set('host', 'evillocalhost:6000').expect(200);
+
+      expect(response.text).toBe('A');
     });
   });
 });

--- a/test/unit/router.spec.ts
+++ b/test/unit/router.spec.ts
@@ -1,3 +1,4 @@
+// spell-checker: ignore evilalpha, evilgamma
 import { getTarget } from '../../src/router';
 
 describe('router unit test', () => {
@@ -106,6 +107,12 @@ describe('router unit test', () => {
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6002');
       });
+
+      it('should not match host-only config when host contains key as substring', () => {
+        fakeReq.headers.host = 'evilalpha.localhost';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with host and host + path config', () => {
@@ -128,6 +135,20 @@ describe('router unit test', () => {
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBe('http://localhost:6003');
       });
+
+      it('should not match host+path config when host is a superstring', () => {
+        fakeReq.headers.host = 'evilgamma.localhost';
+        fakeReq.url = '/api';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match host+path config when host only contains host as a substring', () => {
+        fakeReq.headers.host = 'gamma.localhost.evil';
+        fakeReq.url = '/api/books/123';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
     });
 
     describe('with just the path', () => {
@@ -145,6 +166,12 @@ describe('router unit test', () => {
 
       it('should target http://localhost:6000 path in not present in router config', () => {
         fakeReq.url = '/unknown-path';
+        result = getTarget(fakeReq, proxyOptionWithRouter);
+        return expect(result).resolves.toBeUndefined();
+      });
+
+      it('should not match path config when key appears as non-prefix substring', () => {
+        fakeReq.url = '/prefix/rest';
         result = getTarget(fakeReq, proxyOptionWithRouter);
         return expect(result).resolves.toBeUndefined();
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Backports security fix for GHSA-64mm-vxmg-q3vj

fixes #1266

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

v2 is heavily used by dependencies such as `webpack-dev-server` so having a backport would be very helpful for the ecosystem

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Using the reproduction and with the ported tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] ~My change requires a change to the documentation.~
- [x] ~I have updated the documentation accordingly.~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened router proxy-table matching to prevent routing bypass by enforcing exact host matching and prefix-based path matching instead of substring matching.
  * Added regression tests to ensure malformed host variants cannot incorrectly match routing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->