### PR TITLE
refactor: switch from micromatch to picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "httpxy": "^0.5.4",
     "is-glob": "^4.0.3",
     "is-plain-obj": "^4.1.0",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "picomatch": "^4.0.5"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
@@ -87,6 +88,7 @@
     "@types/is-glob": "4.0.4",
     "@types/micromatch": "4.0.10",
     "@types/node": "26.1.1",
+    "@types/picomatch": "^4.0.3",
     "@types/supertest": "7.2.1",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "httpxy": "^0.5.4",
     "is-glob": "^4.0.3",
     "is-plain-obj": "^4.1.0",
-    "micromatch": "^4.0.8",
     "picomatch": "^4.0.5"
   },
   "devDependencies": {
@@ -86,7 +85,6 @@
     "@types/eslint": "9.6.1",
     "@types/express": "5.0.6",
     "@types/is-glob": "4.0.4",
-    "@types/micromatch": "4.0.10",
     "@types/node": "26.1.1",
     "@types/picomatch": "^4.0.3",
     "@types/supertest": "7.2.1",

--- a/src/path-filter.ts
+++ b/src/path-filter.ts
@@ -1,7 +1,7 @@
 import type * as http from 'node:http';
 
 import isGlob from 'is-glob';
-import micromatch from 'micromatch';
+import picomatch from 'picomatch';
 
 import { HttpProxyMiddlewareError } from './errors.js';
 import type { Filter } from './types.js';
@@ -58,14 +58,41 @@ function matchSingleStringPath(pathFilter: string, uri?: string) {
   return pathname?.indexOf(pathFilter) === 0;
 }
 
-function matchSingleGlobPath(pattern: string | string[], uri?: string) {
+const matchers: Record<string, picomatch.Matcher> = Object.create(null);
+
+function matchSingleGlobPath(pattern: string, uri?: string) {
   const pathname = getUrlPathName(uri) as string;
-  const matches = micromatch([pathname], pattern);
-  return matches && matches.length > 0;
+  const matcher = (matchers[pattern] ??= picomatch(pattern));
+  return matcher(pathname);
 }
 
-function matchMultiGlobPath(patternList: string | string[], uri?: string) {
-  return matchSingleGlobPath(patternList, uri);
+function matchMultiGlobPath(patternList: string[], uri?: string) {
+  const pathname = getUrlPathName(uri) as string;
+
+  let omit = false;
+  let keep = false;
+  let hasPositive = false;
+
+  for (const pattern of patternList) {
+    const matcher = (matchers[pattern] ??= picomatch(pattern));
+    const matched = matcher(pathname, true);
+
+    const negated = matched.state.negated || matched.state.negatedExtglob;
+
+    if (!negated) hasPositive = true;
+
+    const match = negated ? !matched.isMatch : matched.isMatch;
+    if (!match) continue;
+
+    if (negated) {
+      omit = true;
+    } else {
+      omit = false;
+      keep = true;
+    }
+  }
+
+  return (!hasPositive || keep) && !omit;
 }
 
 /**

--- a/src/path-filter.ts
+++ b/src/path-filter.ts
@@ -66,11 +66,13 @@ function matchSingleGlobPath(pattern: string, uri?: string) {
   return matcher(pathname);
 }
 
+// Borrowed from https://github.com/micromatch/micromatch/blob/8bd704ec0d9894693d35da425d827819916be920/index.js#L32
+// Optimized for single path + multi patterns
 function matchMultiGlobPath(patternList: string[], uri?: string) {
   const pathname = getUrlPathName(uri) as string;
 
-  let omit = false;
-  let keep = false;
+  let omited = false;
+  let kept = false;
   let hasPositive = false;
 
   for (const pattern of patternList) {
@@ -85,14 +87,14 @@ function matchMultiGlobPath(patternList: string[], uri?: string) {
     if (!match) continue;
 
     if (negated) {
-      omit = true;
+      omited = true;
     } else {
-      omit = false;
-      keep = true;
+      omited = false;
+      kept = true;
     }
   }
 
-  return (!hasPositive || keep) && !omit;
+  return (!hasPositive || kept) && !omited;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,11 +994,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/braces@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.2.tgz#70009e5d385bc0d804f40f0a3f92285022536730"
-  integrity sha512-U5tlMYa0U/2eFTmJgKcPWQOEICP173sJDa6OjHbj5Tv+NVaYcrq2xmdWpNXOwWYGwJu+jER/pfTLdoQ31q8PzA==
-
 "@types/chai@^5.2.2":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
@@ -1104,13 +1099,6 @@
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
   integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
-
-"@types/micromatch@4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.10.tgz#f83b8b05cea1face2a7cf3b7e866ff97d204b632"
-  integrity sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==
-  dependencies:
-    "@types/braces" "*"
 
 "@types/mime@^1":
   version "1.3.2"
@@ -1554,13 +1542,6 @@ brace-expansion@^5.0.5:
   integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
-
-braces@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
-  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
-  dependencies:
-    fill-range "^7.1.1"
 
 brotli-wasm@^3.0.0:
   version "3.0.1"
@@ -2205,13 +2186,6 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-fill-range@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
-  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
-  dependencies:
-    to-regex-range "^5.0.1"
-
 finalhandler@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -2614,11 +2588,6 @@ is-node-process@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
   integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
 is-plain-obj@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
@@ -2889,14 +2858,6 @@ methods@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
-
-micromatch@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
 
 milliparsec@^5.1.1:
   version "5.1.1"
@@ -3256,11 +3217,6 @@ picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
-
-picomatch@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
-  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
@@ -3812,13 +3768,6 @@ tls-impersonate@^0.1.0:
   integrity sha512-fV5LFIpVmJXkUJiDk1AT9qHMlwVXT7D8Nqs8hhMl9l6I4SgL+jPLRPtV95KNAT3A0ECzritAtUPShhXWwWzoUw==
   dependencies:
     node-gyp-build "^4.8.4"
-
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  dependencies:
-    is-number "^7.0.0"
 
 toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,11 @@
   dependencies:
     undici-types "~8.3.0"
 
+"@types/picomatch@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/picomatch/-/picomatch-4.0.3.tgz#d92bbf24166478c5457c8bb9ba41a7f49d55e094"
+  integrity sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==
+
 "@types/qs@*":
   version "6.9.8"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.8.tgz#f2a7de3c107b89b441e071d5472e6b726b4adf45"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This change replace the `micromatch` dependency with `picomatch`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`picomatch` is a [core engine](https://npmgraph.js.org/?q=micromatch#select=picomatch%402.3.2) behind `micromatch`.
But `micromatch` brings [5 dependencies in its tree](https://npmgraph.js.org/?q=micromatch#select=micromatch%404.0.8) and only `picomatch` that really used in our project.
So, I take a initiative to use the core engine directly.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have do a test when changing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glob pattern matching, including support for combinations of positive and negated patterns.
  * Enhanced matching performance through cached pattern processing.
  * Replaced the underlying matching library without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->